### PR TITLE
Enrich GET /v1/reviews so a reviewer can see what they're approving

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -343,3 +343,57 @@ export interface PendingReview {
    * this. */
   conflictWaivers?: { conflictingDesignId: string }[];
 }
+
+/**
+ * `GET /v1/reviews`'s response shape (2026-08-25). A bare `PendingReview`
+ * carries only the requester's own `justification` plus opaque ids, which
+ * is the least useful subset of what a reviewer needs: it names the
+ * argument for letting the work through without naming the work, who wants
+ * it, or what stopped it. An admin was being asked to approve a sentence.
+ *
+ * Every added field is optional, so this stays a pure superset -- an older
+ * dashboard reading this response is unaffected, and a review whose design
+ * has since been deleted still serializes cleanly rather than 500ing.
+ * Nothing here is stored: it's assembled per request from rows that already
+ * exist (see review-enrich.ts), so there's no schema change and no risk of
+ * the copy drifting from the design it describes.
+ */
+export interface ReviewDesignSummary {
+  summary: string;
+  creates: string[];
+  touches: string[];
+  developerId: string;
+  status: DesignStatement["status"];
+}
+
+export interface ReviewConstraintSummary {
+  id: string;
+  statement: string;
+  type: DesignConstraintType;
+}
+
+/** `overlapWaivers` (path collisions) and `conflictWaivers` (the semantic
+ * comparator's judgement) are separate concepts internally, and an approval
+ * consumes them differently. To a human deciding, they're one question --
+ * "whose work does this collide with, and how do I know?" -- so they're
+ * merged here, with `kind` preserving which check produced it. */
+export interface ReviewConflictSummary {
+  designId: string;
+  kind: "overlap" | "conflict";
+  /** Absent if the conflicting design has since been deleted. */
+  summary?: string;
+  developerId?: string;
+  /** Only ever set for `kind: "overlap"` -- the semantic comparator has no
+   * specific path to point at. */
+  paths?: string[];
+}
+
+export interface EnrichedPendingReview extends PendingReview {
+  /** Absent only if the design was deleted after the review was raised. */
+  design?: ReviewDesignSummary;
+  /** Resolved from `constraintIds`. Absent when the review came from an
+   * overlap rather than a constraint. */
+  constraints?: ReviewConstraintSummary[];
+  /** `overlapWaivers` and `conflictWaivers`, resolved and merged. */
+  conflicts?: ReviewConflictSummary[];
+}

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -456,6 +456,43 @@ test("GET /v1/reviews: defaults to ?status=pending, unchanged from before the qu
   assert.equal(body.items[0].decision, undefined);
 });
 
+// Enriched response (2026-08-25). Before this, the route returned review
+// rows verbatim: the requester's justification plus opaque ids, and nothing
+// about the work itself -- so twing-monitor's card led with the argument for
+// letting something through without ever naming what it was. The unit tests
+// in review-enrich.test.ts cover the assembly; this asserts the route
+// actually wires it up, against a real design created through the real flow.
+test("GET /v1/reviews: carries the design a review is about, not just its justification", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  await makePendingReview(app, admin.token, "proj-1");
+
+  const res = await app.request("/v1/reviews?projectId=proj-1", { headers: bearer(admin.token) });
+  const body = (await res.json()) as {
+    items: {
+      justification: string;
+      design?: { summary: string; developerId: string; touches: string[]; status: string };
+      conflicts?: { designId: string; kind: string; summary?: string }[];
+    }[];
+  };
+
+  const item = body.items[0];
+  // The original field is untouched -- this is a superset, so an older
+  // dashboard reading this response still works exactly as before.
+  assert.ok(item.justification.length > 0);
+
+  assert.ok(item.design, "expected the review to carry its design");
+  assert.ok(item.design.summary.length > 0, "expected a human-readable summary to lead with");
+  assert.ok(item.design.developerId.length > 0, "expected to know who is asking");
+
+  // makePendingReview justifies against a real overlap with a second
+  // developer's design, so the reviewer should be able to see whose work it
+  // collides with -- the question they're actually being asked.
+  assert.ok(item.conflicts && item.conflicts.length > 0, "expected the conflicting design to be named");
+  assert.equal(item.conflicts[0].kind, "overlap");
+  assert.ok(item.conflicts[0].summary, "expected the conflicting design's summary to be resolved");
+});
+
 test("GET /v1/reviews?status=decided: only shows reviews an admin already decided", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -30,6 +30,7 @@ import {
 import { extractDesign } from "./design-extract.js";
 import { checkSemanticConflict } from "./design-semantic-check.js";
 import { findDesignDivergences } from "./design-divergence.js";
+import { enrichReviews } from "./review-enrich.js";
 import { AlignmentThreadStore, buildAlignmentSummary } from "./alignment-store.js";
 import { DrizzleActivityLog, type ActivityEventKind } from "./activity-log.js";
 import { IdentityStore, type ResolvedIdentity, type InviteScope, type Role } from "./identity-store.js";
@@ -1351,7 +1352,18 @@ export function createApp(options: CreateAppOptions = {}) {
     if (status !== "pending" && status !== "decided" && status !== "all") {
       return c.json({ error: "expected ?status= to be pending, decided, or all" }, 400);
     }
-    return c.json({ items: designs.listReviews(projectId, status) });
+    // Enriched (2026-08-25): a bare review row names the argument for
+    // letting work through without naming the work, so a reviewer had
+    // nothing to decide on. Assembled per request from rows that already
+    // exist -- no schema change, and no stored copy that could drift from
+    // the design it describes. Every added field is optional, so an older
+    // dashboard reading this is unaffected. See review-enrich.ts.
+    const items = enrichReviews(
+      designs.listReviews(projectId, status),
+      (id) => designs.get(id),
+      (id) => constraintStore.get(id),
+    );
+    return c.json({ items });
   });
 
   // twing-monitor v1: the dashboard's ActivityView -- newest-first,

--- a/packages/server/src/review-enrich.test.ts
+++ b/packages/server/src/review-enrich.test.ts
@@ -1,0 +1,148 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { PendingReview, DesignStatement, DesignConstraint } from "@twing/core";
+import { enrichReview, enrichReviews } from "./review-enrich.js";
+
+function design(id: string, over: Partial<DesignStatement> = {}): DesignStatement {
+  return {
+    id,
+    projectId: "proj",
+    developerId: "priya@team.dev",
+    sessionId: "sess",
+    status: "flagged",
+    createdAt: 1,
+    lastActivityAt: 1,
+    scopeVersion: 1,
+    summary: "add retry with exponential backoff to the webhook client",
+    creates: ["src/net/retry.ts"],
+    touches: ["src/billing/charge.ts"],
+    dependsOn: [],
+    ttlMs: 1,
+    ...over,
+  } as DesignStatement;
+}
+
+function constraint(id: string, over: Partial<DesignConstraint> = {}): DesignConstraint {
+  return {
+    id,
+    projectId: "proj",
+    type: "review_required",
+    statement: "money paths need a second pair of eyes",
+    scope: ["src/billing/**"],
+    source: ".twing/twing.yml",
+    createdAt: 1,
+    ...over,
+  } as DesignConstraint;
+}
+
+function review(over: Partial<PendingReview> = {}): PendingReview {
+  return {
+    id: "rev_1",
+    designId: "dsn_mine",
+    projectId: "proj",
+    justification: "webhook retries need different backoff to API retries",
+    createdAt: 1,
+    ...over,
+  };
+}
+
+const none = () => undefined;
+
+test("carries the design through, so a reviewer sees the work and not just the argument for it", () => {
+  const out = enrichReview(review(), (id) => (id === "dsn_mine" ? design("dsn_mine") : undefined), none);
+
+  assert.equal(out.design?.summary, "add retry with exponential backoff to the webhook client");
+  assert.equal(out.design?.developerId, "priya@team.dev");
+  assert.deepEqual(out.design?.touches, ["src/billing/charge.ts"]);
+  assert.equal(out.design?.status, "flagged");
+  // The original fields must survive untouched -- this is a superset, not a
+  // replacement shape.
+  assert.equal(out.justification, "webhook retries need different backoff to API retries");
+  assert.equal(out.id, "rev_1");
+});
+
+test("resolves constraint ids into the actual rule text", () => {
+  const out = enrichReview(
+    review({ constraintIds: ["c1"] }),
+    none,
+    (id) => (id === "c1" ? constraint("c1") : undefined),
+  );
+
+  assert.equal(out.constraints?.length, 1);
+  assert.equal(out.constraints?.[0].statement, "money paths need a second pair of eyes");
+  assert.equal(out.constraints?.[0].type, "review_required");
+});
+
+test("merges overlap and semantic-conflict waivers into one list, keeping which check produced each", () => {
+  const out = enrichReview(
+    review({
+      overlapWaivers: [{ conflictingDesignId: "dsn_other", paths: ["src/billing/charge.ts"] }],
+      conflictWaivers: [{ conflictingDesignId: "dsn_third" }],
+    }),
+    (id) =>
+      id === "dsn_other"
+        ? design("dsn_other", { summary: "billing retry work", developerId: "ayush@team.dev" })
+        : id === "dsn_third"
+          ? design("dsn_third", { summary: "webhook rework", developerId: "sam@team.dev" })
+          : undefined,
+    none,
+  );
+
+  assert.equal(out.conflicts?.length, 2);
+  assert.equal(out.conflicts?.[0].kind, "overlap");
+  assert.equal(out.conflicts?.[0].summary, "billing retry work");
+  assert.deepEqual(out.conflicts?.[0].paths, ["src/billing/charge.ts"]);
+  // A semantic conflict has no specific colliding path to name.
+  assert.equal(out.conflicts?.[1].kind, "conflict");
+  assert.equal(out.conflicts?.[1].developerId, "sam@team.dev");
+  assert.equal(out.conflicts?.[1].paths, undefined);
+});
+
+// The listing must survive rows that reference things which no longer
+// exist: `twing constraints remove` is unilateral and immediate, and a
+// design can be deleted after a review was raised against it. Neither may
+// take down the whole page.
+test("a review whose design is gone still enriches, minus the design", () => {
+  const out = enrichReview(review(), none, none);
+
+  assert.equal(out.design, undefined);
+  assert.equal(out.justification, "webhook retries need different backoff to API retries");
+});
+
+test("a constraint removed since the review was raised is dropped, not rendered as a bare id", () => {
+  const out = enrichReview(review({ constraintIds: ["gone", "c1"] }), none, (id) =>
+    id === "c1" ? constraint("c1") : undefined,
+  );
+
+  assert.equal(out.constraints?.length, 1);
+  assert.equal(out.constraints?.[0].id, "c1");
+});
+
+test("a conflicting design that's gone keeps its id, so the reviewer still knows something collided", () => {
+  const out = enrichReview(
+    review({ overlapWaivers: [{ conflictingDesignId: "dsn_gone", paths: ["a.ts"] }] }),
+    none,
+    none,
+  );
+
+  assert.equal(out.conflicts?.length, 1);
+  assert.equal(out.conflicts?.[0].designId, "dsn_gone");
+  assert.equal(out.conflicts?.[0].summary, undefined);
+});
+
+test("omits empty collections entirely rather than sending empty arrays", () => {
+  const out = enrichReview(review(), none, none);
+
+  assert.equal(out.constraints, undefined);
+  assert.equal(out.conflicts, undefined);
+});
+
+test("enrichReviews preserves order", () => {
+  const out = enrichReviews(
+    [review({ id: "a" }), review({ id: "b" }), review({ id: "c" })],
+    none,
+    none,
+  );
+
+  assert.deepEqual(out.map((r) => r.id), ["a", "b", "c"]);
+});

--- a/packages/server/src/review-enrich.ts
+++ b/packages/server/src/review-enrich.ts
@@ -1,0 +1,107 @@
+/**
+ * Turns a bare `PendingReview` into the shape a human can actually decide
+ * on (2026-08-25).
+ *
+ * The problem this solves: `listReviews` returns review rows verbatim, so
+ * `GET /v1/reviews` carried the requester's `justification` and a handful
+ * of opaque ids -- and nothing about the work itself. twing-monitor's
+ * review card therefore led with the justification, which meant an admin
+ * was shown the argument for letting something through without being shown
+ * what it was, who wanted it, or what had stopped it. The question a
+ * reviewer is really being asked is "do I want this to happen?", and the
+ * response didn't contain enough to answer it.
+ *
+ * Deliberately a pure function over injected lookups rather than a method
+ * on `DesignRegistry`: the enrichment spans the design registry *and* the
+ * constraint store, and making either own it would couple two stores that
+ * are otherwise independent. Same reasoning as `design-checks.ts` staying
+ * pure -- it makes this trivially testable with plain maps, no db.
+ *
+ * Every added field is optional. A review whose design has since been
+ * deleted enriches to the same object minus `design`, rather than throwing:
+ * a stale row must never be able to take down the whole listing.
+ */
+
+import type {
+  PendingReview,
+  EnrichedPendingReview,
+  ReviewConflictSummary,
+  DesignStatement,
+  DesignConstraint,
+} from "@twing/core";
+
+export type DesignLookup = (id: string) => DesignStatement | undefined;
+export type ConstraintLookup = (id: string) => DesignConstraint | undefined;
+
+/** `overlapWaivers` and `conflictWaivers` answer the same human question --
+ * "whose work does this collide with?" -- so they're merged into one list,
+ * `kind` preserving which check produced each. Order is stable: overlaps
+ * first, then semantic conflicts, each in the order recorded. */
+function collectConflicts(review: PendingReview, lookupDesign: DesignLookup): ReviewConflictSummary[] {
+  const out: ReviewConflictSummary[] = [];
+
+  for (const waiver of review.overlapWaivers ?? []) {
+    const other = lookupDesign(waiver.conflictingDesignId);
+    out.push({
+      designId: waiver.conflictingDesignId,
+      kind: "overlap",
+      ...(other ? { summary: other.summary, developerId: other.developerId } : {}),
+      ...(waiver.paths.length > 0 ? { paths: waiver.paths } : {}),
+    });
+  }
+
+  for (const waiver of review.conflictWaivers ?? []) {
+    const other = lookupDesign(waiver.conflictingDesignId);
+    out.push({
+      designId: waiver.conflictingDesignId,
+      kind: "conflict",
+      ...(other ? { summary: other.summary, developerId: other.developerId } : {}),
+    });
+  }
+
+  return out;
+}
+
+export function enrichReview(
+  review: PendingReview,
+  lookupDesign: DesignLookup,
+  lookupConstraint: ConstraintLookup,
+): EnrichedPendingReview {
+  const design = lookupDesign(review.designId);
+
+  // A constraint removed since the review was raised (`twing constraints
+  // remove` is unilateral and immediate) leaves an id that resolves to
+  // nothing. Dropping it silently is right: the rule genuinely no longer
+  // applies, and showing a bare id would be worse than showing nothing.
+  const constraints = (review.constraintIds ?? [])
+    .map(lookupConstraint)
+    .filter((c): c is DesignConstraint => c !== undefined)
+    .map((c) => ({ id: c.id, statement: c.statement, type: c.type }));
+
+  const conflicts = collectConflicts(review, lookupDesign);
+
+  return {
+    ...review,
+    ...(design
+      ? {
+          design: {
+            summary: design.summary,
+            creates: design.creates,
+            touches: design.touches,
+            developerId: design.developerId,
+            status: design.status,
+          },
+        }
+      : {}),
+    ...(constraints.length > 0 ? { constraints } : {}),
+    ...(conflicts.length > 0 ? { conflicts } : {}),
+  };
+}
+
+export function enrichReviews(
+  reviews: PendingReview[],
+  lookupDesign: DesignLookup,
+  lookupConstraint: ConstraintLookup,
+): EnrichedPendingReview[] {
+  return reviews.map((r) => enrichReview(r, lookupDesign, lookupConstraint));
+}


### PR DESCRIPTION
## Why

`listReviews` returns review rows verbatim, so `GET /v1/reviews` carried the requester's own `justification` plus a handful of opaque ids — and nothing about the work itself.

twing-monitor's review card therefore led with the justification. An admin was shown **the argument for letting something through, without being shown what it was, who wanted it, or what had stopped it.**

That's the least neutral piece of information available, and the one you'd least want to decide from. The question a reviewer is actually being asked is *"do I want this to happen?"* — and the response didn't contain enough to answer it.

## What's added

Three optional fields, assembled per request from rows that already exist:

| Field | Contents |
|---|---|
| `design` | `summary`, `creates`, `touches`, `developerId`, `status` |
| `constraints` | `constraintIds` resolved to their real rule text |
| `conflicts` | `overlapWaivers` + `conflictWaivers`, resolved to the other design's summary and owner |

**No schema change, no migration.** Nothing is stored, so there's no copy that can drift from the design it describes.

**Pure superset** — every field optional, so an older dashboard reading this response is unaffected.

## Design notes

**Waivers are merged.** `overlapWaivers` (path collisions) and `conflictWaivers` (the semantic comparator's judgement) stay separate internally, since an approval consumes them differently. To a human deciding, they're one question — *whose work does this collide with* — so they're merged into `conflicts` with `kind` preserving which check produced each. Splitting them across two response fields only pushed that join into the UI.

**`review-enrich.ts` is a pure function over injected lookups**, not a method on `DesignRegistry`. The enrichment spans the design registry *and* the constraint store; making either own it would couple two stores that are otherwise independent. Same reasoning as `design-checks.ts` staying pure — and it makes the whole thing testable with plain maps and no db.

## Stale references can't break the listing

`twing constraints remove` is unilateral and immediate, and a design can be deleted after a review was raised against it. All three cases are covered:

- missing design → enriches minus `design`, rather than throwing
- removed constraint → dropped, rather than rendered as a bare id
- missing conflicting design → keeps its id, so the reviewer still knows something collided

## Tests

`296` server tests pass — 8 new unit tests in `review-enrich.test.ts`, plus one integration test asserting the route actually wires it up against a design created through the real flow. `435` across all workspaces.

## Paired with

twing-monitor `feat/readable-review-cards`, which consumes this. **Merge this first** — the dashboard can't improve until the data exists, though it degrades cleanly either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)