### PR TITLE
Design-gate registration-sprawl fixes: join hint, hard block, out-of-scope multi-candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,12 @@ the same work before that becomes a merge conflict or a design disagreement
 discovered too late.
 
 Each deny message already tells you the specific command to run
-(`twing design register`, `amend`, `resume`, or `resolve --justify`) --
-follow it, then retry the original edit. Two things worth knowing before you
-do:
+(`twing design register`, `amend`, `resume`, or `resolve --justify`) -- or,
+on a fresh session's very first deny, to check `twing design list --mine
+--status open` first and join an existing open design of yours via `amend
+--group` if one already covers the same effort, rather than registering a
+new one for it. Follow whichever it tells you, then retry the original
+edit. Two things worth knowing before you do:
 
 - **`resolve --justify` records a justification, it does not itself unblock
   you.** It queues a `PendingReview` for a project admin to approve or

--- a/hook/design_gate.go
+++ b/hook/design_gate.go
@@ -860,6 +860,13 @@ func noDesignReason() string {
 				Note: "The summary is what teammates see if your work overlaps theirs, " +
 					"so describe the real goal rather than a placeholder.",
 			},
+			{
+				Label:   "Or join what you already have open",
+				Command: "twing design list --mine --status open",
+				Note: "If one of these is the same effort as what you're about to do, link " +
+					"this into it instead of starting a new one: twing design amend --id <id> " +
+					"--group <id> (or --touches/--summary to just widen it).",
+			},
 		},
 	)
 }
@@ -978,6 +985,27 @@ type designScopeMatchResponse struct {
 	// Both used to deny with the identical message telling you to run
 	// `twing design resolve`, even immediately after you already had.
 	PendingReview bool `json:"pendingReview,omitempty"`
+	// Set only for state "out_of_scope" (2026-08-25) -- every open design
+	// for this session, newest-first, not just the one `DesignID` names.
+	// Found live: with more than one open design in a session, silently
+	// picking just `DesignID` to suggest amending offered no way to see (or
+	// choose) the others -- and the field it picked from was actually the
+	// *oldest* one (array-index-off-newest-first-order bug), not even the
+	// best single guess. Deliberately backward-compatible: an older
+	// coordinator that doesn't send this field yet leaves it empty, and
+	// outOfScopeReason falls back to a one-candidate list built from
+	// `DesignID` alone.
+	OpenDesigns []designSummary `json:"openDesigns,omitempty"`
+}
+
+// designSummary is the minimal per-design context outOfScopeReason needs to
+// render an actionable candidate -- id (for the amend command) and summary
+// (for a human/agent to judge "is this the same task"). Distinct from
+// designConflict/designConstraintInfo above -- those describe a *check*
+// result, this describes a plain design row.
+type designSummary struct {
+	ID      string `json:"id"`
+	Summary string `json:"summary,omitempty"`
 }
 
 // checkDesignScope is §17 scope enforcement's (2026-08) ground-truth
@@ -1049,24 +1077,61 @@ func flaggedDesignReason(designID string, pendingReview bool) string {
 	)
 }
 
-func outOfScopeReason(designID, path string) string {
-	return denyMessage(
-		"You're changing a file you didn't mention in your plan.",
-		"twing can't tell whether that's a natural part of your work or the start of a "+
-			"collision with someone else, so it's asking first.",
-		[]denyDetail{{"File", path}, {"Your plan", designID}},
-		[]denyAction{
-			{
-				Label:   "Add it to your plan",
-				Command: fmt.Sprintf("twing design amend --id %s --touches %s", designID, path),
-				Note:    "This is re-checked against other active sessions, not a silent expansion.",
-			},
-			{
-				Label: "Or register a separate plan",
-				Note:  "Use this if the change is genuinely unrelated to what you registered.",
-			},
-		},
-	)
+// maxOutOfScopeCandidates caps how many of a session's open designs
+// outOfScopeReason lists as amend candidates -- a deny message is meant to
+// be scanned in a few seconds, not read like `twing design list`'s own
+// output. Past this, the remaining count is folded into one more action
+// pointing at that command instead of one row per design.
+const maxOutOfScopeCandidates = 5
+
+func outOfScopeReason(designID, path string, openDesigns []designSummary) string {
+	// Backward compatible with a coordinator that doesn't send OpenDesigns
+	// yet (see designScopeMatchResponse's own doc comment) -- falls back to
+	// the single id it does send, with no summary to show.
+	candidates := openDesigns
+	if len(candidates) == 0 && designID != "" {
+		candidates = []designSummary{{ID: designID}}
+	}
+
+	headline := "You're changing a file you didn't mention in your plan."
+	why := "twing can't tell whether that's a natural part of your work or the start of a " +
+		"collision with someone else, so it's asking first."
+	if len(candidates) > 1 {
+		headline = "You're changing a file none of your open plans mention."
+		why = "You have more than one plan open in this session, and none of them cover " +
+			"this file. twing can't tell whether that's a natural part of one of them " +
+			"or the start of a collision with someone else, so it's asking first."
+	}
+
+	shown := candidates
+	if len(shown) > maxOutOfScopeCandidates {
+		shown = shown[:maxOutOfScopeCandidates]
+	}
+
+	actions := make([]denyAction, 0, len(shown)+2)
+	for _, d := range shown {
+		label := "Add it to your plan"
+		if d.Summary != "" {
+			label = fmt.Sprintf("Add it to %q", d.Summary)
+		}
+		actions = append(actions, denyAction{
+			Label:   label,
+			Command: fmt.Sprintf("twing design amend --id %s --touches %s", d.ID, path),
+			Note:    "This is re-checked against other active sessions, not a silent expansion.",
+		})
+	}
+	if extra := len(candidates) - len(shown); extra > 0 {
+		actions = append(actions, denyAction{
+			Label:   fmt.Sprintf("...and %d more open plan(s), not shown above", extra),
+			Command: "twing design list --mine --status open",
+		})
+	}
+	actions = append(actions, denyAction{
+		Label: "Or register a separate plan",
+		Note:  "Use this if the change is genuinely unrelated to what you registered.",
+	})
+
+	return denyMessage(headline, why, []denyDetail{{"File", path}}, actions)
 }
 
 // dormantSinceText renders a millisecond duration as a coarse,
@@ -1331,7 +1396,7 @@ func handleEditWriteGate(payload hookPayload) {
 	case "dormant":
 		writeJSON(denyOutput("PreToolUse", dormantDesignReason(scopeMatch.DesignID, scopeMatch.Summary, scopeMatch.DormantSinceMs)))
 	case "out_of_scope":
-		writeJSON(denyOutput("PreToolUse", outOfScopeReason(scopeMatch.DesignID, relPath)))
+		writeJSON(denyOutput("PreToolUse", outOfScopeReason(scopeMatch.DesignID, relPath, scopeMatch.OpenDesigns)))
 	case "no_design":
 		writeJSON(denyOutput("PreToolUse", noDesignReason()))
 	default:

--- a/hook/design_gate_test.go
+++ b/hook/design_gate_test.go
@@ -440,6 +440,72 @@ func TestHandleEditWriteGate_OutOfScope_DeniesWithAmendInstructions(t *testing.T
 	}
 }
 
+// Found live (2026-08-25): with more than one open design in the session,
+// the deny used to silently pick just one (and the *oldest* one, an
+// unrelated bug on the server side -- see app.ts's own comment) instead of
+// offering every candidate. This is the fix: every open design in
+// `openDesigns` gets its own amend command.
+func TestHandleEditWriteGate_OutOfScope_MultipleOpenDesigns_OffersEveryOneAsAnAmendCandidate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/constraints/match":
+			_, _ = w.Write([]byte(`{"matched":false}`))
+		case "/v1/designs/scope-match":
+			_, _ = w.Write([]byte(`{"state":"out_of_scope","designId":"d-newest","openDesigns":[
+				{"id":"d-newest","summary":"the current task"},
+				{"id":"d-oldest","summary":"an earlier, unrelated task"}
+			]}`))
+		}
+	}))
+	defer server.Close()
+
+	repo := newTestRepo(t, server.URL)
+	setCachedToken(t, server.URL, "some-token")
+
+	stdout := captureStdout(t, func() { handleEditWriteGate(editPayload(repo, "sess1")) })
+	decision, reason := decisionOf(t, stdout)
+	if decision != "deny" {
+		t.Fatalf("decision = %q, want deny", decision)
+	}
+	for _, want := range []string{"d-newest", "the current task", "d-oldest", "an earlier, unrelated task"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("reason missing %q -- every open design must be offered, not just one\n%s", want, reason)
+		}
+	}
+	if strings.Count(reason, "design amend --id") != 2 {
+		t.Errorf("reason should offer exactly 2 amend commands, one per open design:\n%s", reason)
+	}
+}
+
+func TestOutOfScopeReason_CapsTheListAndFoldsTheRestIntoACount(t *testing.T) {
+	candidates := make([]designSummary, 0, maxOutOfScopeCandidates+3)
+	for i := 0; i < maxOutOfScopeCandidates+3; i++ {
+		candidates = append(candidates, designSummary{ID: fmt.Sprintf("d%d", i), Summary: fmt.Sprintf("task %d", i)})
+	}
+	reason := outOfScopeReason(candidates[0].ID, "src/net/retry.ts", candidates)
+
+	if got := strings.Count(reason, "design amend --id"); got != maxOutOfScopeCandidates {
+		t.Errorf("amend commands = %d, want exactly the cap (%d)", got, maxOutOfScopeCandidates)
+	}
+	if !strings.Contains(reason, "3 more") {
+		t.Errorf("reason should say how many more are hidden (3), got:\n%s", reason)
+	}
+	if !strings.Contains(reason, "design list --mine --status open") {
+		t.Errorf("reason should point at `design list --mine --status open` to see the rest, got:\n%s", reason)
+	}
+	// The candidates past the cap must not leak into the message at all.
+	if strings.Contains(reason, candidates[maxOutOfScopeCandidates].ID) {
+		t.Errorf("reason names a candidate past the cap: %q", candidates[maxOutOfScopeCandidates].ID)
+	}
+}
+
+func TestOutOfScopeReason_SingleCandidate_NoCountingLanguage(t *testing.T) {
+	reason := outOfScopeReason("d1", "src/net/retry.ts", []designSummary{{ID: "d1", Summary: "the current task"}})
+	if strings.Contains(reason, "more than one") || strings.Contains(reason, "more open plan") {
+		t.Errorf("a single candidate must not talk about multiple plans:\n%s", reason)
+	}
+}
+
 func TestHandleEditWriteGate_NoCoordinatorConfigured_SilentNoOp(t *testing.T) {
 	repo := newTestRepo(t, "") // no .twing/twing.yml at all
 	setCachedToken(t, "http://unused.invalid", "")
@@ -981,7 +1047,11 @@ func allDenyMessages(t *testing.T) map[string]string {
 		"noDesign":           noDesignReason(),
 		"flagged":            flaggedDesignReason("11111111-2222-3333-4444-555555555555", false),
 		"flaggedPendingRev":  flaggedDesignReason("11111111-2222-3333-4444-555555555555", true),
-		"outOfScope":         outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts"),
+		"outOfScope":         outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts", nil),
+		"outOfScopeMulti": outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts", []designSummary{
+			{ID: "11111111-2222-3333-4444-555555555555", Summary: "add retry with backoff"},
+			{ID: "66666666-7777-8888-9999-000000000000", Summary: "unrelated debounce helper"},
+		}),
 		"dormant":            dormantDesignReason("11111111-2222-3333-4444-555555555555", "adds retry", 7200000),
 		"overlap":            overlapReason(overlap),
 		"constraint":         constraintReason(constraint),
@@ -1088,6 +1158,22 @@ func TestDormantDesignReason_OmitsMissingSummary(t *testing.T) {
 	}
 	if !strings.Contains(msg, "What now") {
 		t.Errorf("should still render actions, got %q", msg)
+	}
+}
+
+// The "no design" deny previously offered only "register something new"
+// (plan mode, or `design register`) -- a session with an already-open
+// design elsewhere in the project (e.g. from earlier the same day) had no
+// suggested path to join it instead, which is most of why unrelated small
+// fixes ended up as their own untracked designs rather than `--group`-linked
+// into the ongoing effort (twing-cli issue, 2026-08-25).
+func TestNoDesignReason_SuggestsJoiningAnExistingOpenDesign(t *testing.T) {
+	msg := noDesignReason()
+	if !strings.Contains(msg, "twing design list --mine --status open") {
+		t.Errorf("should point at listing the caller's own open designs, got %q", msg)
+	}
+	if !strings.Contains(msg, "amend --id") || !strings.Contains(msg, "--group") {
+		t.Errorf("should suggest amend --group as the follow-up, got %q", msg)
 	}
 }
 

--- a/packages/cli/src/design.test.ts
+++ b/packages/cli/src/design.test.ts
@@ -22,7 +22,7 @@ import {
   runDesignEnableGate,
   runDesignDisableGate,
 } from "./design.js";
-import { tmpRepo, withHome, cacheToken, withMockFetch, withEnv, captureConsole, jsonResponse, captureFetch } from "./test-support.js";
+import { tmpRepo, withHome, cacheToken, withMockFetch, withEnv, captureConsole, jsonResponse, captureFetch, setUserEmail } from "./test-support.js";
 
 const SERVER_URL = "http://localhost:9999";
 
@@ -131,6 +131,50 @@ test("runDesignRegister: prints no group line when the response has no groupId",
     const repo = tmpRepo(SERVER_URL);
     const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "solo" })));
     assert.ok(!logs.some((l) => l.includes("group:")), 'must not print "group: undefined" or similar when groupId is absent');
+  });
+});
+
+// "Force a choice" registration-sprawl fix (2026-08-25)
+
+test("runDesignRegister: --force sends force: true in the request body", async () => {
+  const { fetch, calls } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1", groupId: "d1" }));
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    await withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "genuinely new", force: true }));
+    const body = calls[0].body as Record<string, unknown>;
+    assert.equal(body.force, true);
+  });
+});
+
+test("runDesignRegister: omitting --force sends no force field at all", async () => {
+  const { fetch, calls } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1", groupId: "d1" }));
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    await withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "solo" }));
+    const body = calls[0].body as Record<string, unknown>;
+    assert.equal("force" in body, false, "must be omitted entirely, not sent as an explicit false");
+  });
+});
+
+test("runDesignRegister: a has_open_designs verdict lists the other open designs and the three next-step commands", async () => {
+  const { fetch } = captureFetch(
+    jsonResponse({
+      verdict: "has_open_designs",
+      severity: "error",
+      openDesigns: [{ id: "d-old", projectId: "proj-x", summary: "an older, still-open task", lastActivityAt: 1 }],
+    }),
+  );
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "new task" })));
+    assert.ok(logs.some((l) => l.includes("verdict: has_open_designs")));
+    assert.ok(logs.some((l) => l.includes("d-old") && l.includes("an older, still-open task")));
+    assert.ok(logs.some((l) => l.includes("--group")));
+    assert.ok(logs.some((l) => l.includes("design close")));
+    assert.ok(logs.some((l) => l.includes("--force")));
   });
 });
 
@@ -299,6 +343,45 @@ test("runDesignList: appends ?status= and prints last-activity staleness", async
     const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignList({ cwd: repo, status: "dormant" })));
     assert.match(calls[0].url, /[?&]status=dormant/);
     assert.ok(logs.some((l) => l.includes("[dormant]") && l.includes("last activity 2h ago") && l.includes("old work")));
+  });
+});
+
+test("runDesignList: --mine filters to the caller's own developerId, client-side, sending no extra query param", async () => {
+  const { fetch, calls } = captureFetch(
+    jsonResponse({
+      items: [
+        { id: "mine", status: "open", summary: "my work", creates: [], touches: [], developerId: "erin@example.com" },
+        { id: "theirs", status: "open", summary: "someone else's work", creates: [], touches: [], developerId: "someone-else@example.com" },
+      ],
+    }),
+  );
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    setUserEmail(repo, "erin@example.com");
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignList({ cwd: repo, mine: true })));
+    assert.ok(!calls[0].url.includes("mine"), "filtering is client-side -- no ?mine= param sent");
+    assert.ok(logs.some((l) => l.includes("my work")));
+    assert.ok(!logs.some((l) => l.includes("someone else's work")));
+  });
+});
+
+test("runDesignList: without --mine, prints every design regardless of developerId", async () => {
+  const { fetch } = captureFetch(
+    jsonResponse({
+      items: [
+        { id: "mine", status: "open", summary: "my work", creates: [], touches: [], developerId: "erin@example.com" },
+        { id: "theirs", status: "open", summary: "someone else's work", creates: [], touches: [], developerId: "someone-else@example.com" },
+      ],
+    }),
+  );
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    setUserEmail(repo, "erin@example.com");
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignList({ cwd: repo })));
+    assert.ok(logs.some((l) => l.includes("my work")));
+    assert.ok(logs.some((l) => l.includes("someone else's work")));
   });
 });
 

--- a/packages/cli/src/design.ts
+++ b/packages/cli/src/design.ts
@@ -54,7 +54,9 @@ interface DesignConflictJSON {
 
 interface DesignCheckResponseJSON {
   error?: string;
-  verdict?: "clean" | "overlap" | "constraint_flag";
+  verdict?: "clean" | "overlap" | "constraint_flag" | "has_open_designs";
+  /** Absent only for `"has_open_designs"` -- that verdict fires before any
+   * row is created. See DesignVerdict's own doc comment in core/types.ts. */
   designId?: string;
   /** §17 design linking (2026-08) -- the design's own groupId, self-assigned
    * or caller-supplied. Copy this into a sibling repo's
@@ -69,6 +71,10 @@ interface DesignCheckResponseJSON {
    * currently) is display-only, undefined/"error" means today's original
    * blocking behavior. See DesignSeverity's doc comment in core/types.ts. */
   severity?: "warning" | "error";
+  /** Set only for `"has_open_designs"` (2026-08-25, "force a choice"
+   * registration-sprawl fix) -- the developer's other currently-open
+   * designs, cross-project, found before this registration was created. */
+  openDesigns?: { id: string; projectId: string; summary: string; lastActivityAt: number }[];
 }
 
 async function parseJsonOrUnauthorized<T>(res: Response): Promise<T | { error: string }> {
@@ -81,7 +87,11 @@ function printDesignVerdict(result: DesignCheckResponseJSON): void {
     console.error(`twing design: ${result.error}`);
     return;
   }
-  console.log(`verdict: ${result.verdict}${result.severity ? ` (${result.severity})` : ""}  design: ${result.designId}`);
+  // "has_open_designs" (2026-08-25) has no designId -- no row exists yet
+  // for this verdict, see DesignCheckResult.designId's own doc comment.
+  console.log(
+    `verdict: ${result.verdict}${result.severity ? ` (${result.severity})` : ""}` + (result.designId ? `  design: ${result.designId}` : ""),
+  );
   if (result.groupId) {
     // §17 design linking (2026-08): the copy-paste hint for linking a
     // sibling-repo registration to this one.
@@ -106,6 +116,15 @@ function printDesignVerdict(result: DesignCheckResponseJSON): void {
       console.log(`  [${c.type}] ${c.statement}`);
     }
     console.log(`  -> adjust your plan, or run: twing design resolve --id ${result.designId} --justify "<reason>"`);
+  } else if (result.verdict === "has_open_designs") {
+    // "Force a choice" registration-sprawl fix (2026-08-25): no row was
+    // created for this call -- nothing to point `resolve`/`close` at yet.
+    for (const d of result.openDesigns ?? []) {
+      console.log(`  open: ${d.id}  (project ${d.projectId}) -- "${d.summary || "no summary"}"`);
+    }
+    console.log(`  -> if this is a continuation, link it: twing design register ... --group <id>`);
+    console.log(`  -> if that work is done, close it first: twing design close --id <id>`);
+    console.log(`  -> if this is genuinely new, override: twing design register ... --force`);
   }
 }
 
@@ -121,6 +140,11 @@ export interface RegisterOptions {
    * design (typically in another repo) sharing the same unit of work --
    * pass the `groupId` printed by that design's own registration. */
   group?: string;
+  /** "Force a choice" registration-sprawl fix (2026-08-25): explicit
+   * override of the has-open-designs pre-registration check -- for a
+   * genuinely new, unrelated design registered while another is still
+   * open. See DesignCheckRequestBody.force's doc comment (packages/server). */
+  force?: boolean;
 }
 
 /**
@@ -187,6 +211,7 @@ export async function runDesignRegister(options: RegisterOptions): Promise<void>
         touches: splitList(options.touches),
         dependsOn: splitList(options.dependsOn),
         ...(options.group ? { groupId: options.group } : {}),
+        ...(options.force ? { force: true } : {}),
       }),
     },
     authToken,
@@ -376,6 +401,14 @@ export async function runDesignResume(options: ResumeOptions): Promise<void> {
 export interface ListOptions {
   cwd: string;
   status?: string;
+  /** Filters to designs registered under the caller's own `developerId` --
+   * purely client-side (the server response already carries `developerId`
+   * per row; this just narrows what gets printed), so no new query param.
+   * Point of this flag: give a session hitting `noDesignReason()`'s "no
+   * design registered" deny a fast way to check whether it already has an
+   * open design elsewhere in the project it should join (`amend --group`)
+   * instead of registering a fresh one for the same ongoing effort. */
+  mine?: boolean;
 }
 
 /** Coarse, human-readable approximation ("3h ago", "2d ago") -- mirrors
@@ -404,9 +437,10 @@ export async function runDesignList(options: ListOptions): Promise<void> {
     return;
   }
   const body = (await res.json()) as {
-    items?: { id: string; status: string; summary: string; creates: string[]; touches: string[]; lastActivityAt?: number }[];
+    items?: { id: string; status: string; summary: string; creates: string[]; touches: string[]; lastActivityAt?: number; developerId: string }[];
   };
-  for (const d of body.items ?? []) {
+  const items = options.mine ? (body.items ?? []).filter((d) => d.developerId === developerId) : (body.items ?? []);
+  for (const d of items) {
     const activity = d.lastActivityAt ? `  last activity ${relativeTime(d.lastActivityAt)}` : "";
     console.log(`${d.id}  [${d.status}]${activity}  ${d.summary || "(no summary)"}  creates=${d.creates.join(",")}  touches=${d.touches.join(",")}`);
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,12 +97,12 @@ function printUsage(): void {
       "  twing project revoke-invite --code <invite-code> [--server <url>]",
       "  twing project remove-developer --developer-id <id> [--project <id>] [--server <url>]",
       "  twing project list-developers [--project <id>] [--server <url>]",
-      "  twing design register --session <id> --summary \"...\" --creates a,b --touches c,d --depends-on e,f [--group <groupId>]",
+      "  twing design register --session <id> --summary \"...\" --creates a,b --touches c,d --depends-on e,f [--group <groupId>] [--force]",
       "  twing design resolve --id <designId> (--adopt <designId> | --justify \"...\")",
       "  twing design amend --id <designId> [--touches a,b] [--creates c,d] [--depends-on e,f] [--summary \"...\"] [--group <groupId>]",
       "  twing design resume --id <designId> [--session <id>] [--touches a,b] [--creates c,d] [--depends-on e,f]",
       "  twing design close --id <designId>",
-      "  twing design list [--status open]",
+      "  twing design list [--status open] [--mine]",
       "  twing design reviews [--decide <reviewId> --decision approve|reject]",
       "  twing design enable-gate",
       "  twing design disable-gate",
@@ -140,6 +140,7 @@ async function runDesignCommand(rest: string[]): Promise<void> {
         touches: flags.touches,
         dependsOn: flags["depends-on"],
         group: flags.group,
+        force: flags.force === "true",
       });
       return;
     case "resolve":
@@ -155,7 +156,7 @@ async function runDesignCommand(rest: string[]): Promise<void> {
       await runDesignClose({ cwd, id: flags.id });
       return;
     case "list":
-      await runDesignList({ cwd, status: flags.status });
+      await runDesignList({ cwd, status: flags.status, mine: flags.mine === "true" });
       return;
     case "reviews":
       await runDesignReviews({ cwd, decide: flags.decide, decision: flags.decision === "approve" || flags.decision === "reject" ? flags.decision : undefined });

--- a/packages/cli/src/test-support.ts
+++ b/packages/cli/src/test-support.ts
@@ -38,6 +38,15 @@ export function addGithubRemote(repo: string, owner: string, name: string): void
   execFileSync("git", ["remote", "add", "origin", `https://github.com/${owner}/${name}.git`], { cwd: repo });
 }
 
+/** Sets a `tmpRepo()`'s local `user.email` -- a fresh `git init` has none of
+ * its own, so `computeDeveloperId` (git-email-derived) would otherwise fall
+ * through to whatever's in the *host machine's* global git config, which is
+ * unset/unpredictable in CI. Needed by any test that depends on a specific,
+ * deterministic `developerId` (e.g. `--mine` filtering). */
+export function setUserEmail(repo: string, email: string): void {
+  execFileSync("git", ["config", "user.email", email], { cwd: repo });
+}
+
 /** Points `os.homedir()` (via $HOME) at an isolated dir for the duration of
  * `run` -- never touches the real machine's `~/.twing/config.json`, same
  * reasoning as the Go gate tests' `setCachedToken`. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -253,8 +253,17 @@ export interface DesignConstraint {
  * `DesignCheckResult` (design-checks.ts's tiers 1-4 run synchronously
  * against the request that triggered them); only ever set via
  * `DesignRegistry.flag()` from the async comparator pass, after its
- * response has already been sent. */
-export type DesignVerdict = "clean" | "overlap" | "constraint_flag" | "conflict";
+ * response has already been sent.
+ *
+ * `"has_open_designs"` (2026-08-25): a pre-registration check, distinct from
+ * the tiers above in that it runs *before* any row exists for this request
+ * at all -- `overlap`/`constraint_flag`/`conflict` all presuppose a design
+ * was already created and are about that design's relationship to others;
+ * this one is about whether registration should even proceed. Only reachable
+ * from `POST /v1/designs/check`'s structured (non-`rawPlanText`) path, i.e.
+ * `twing design register`, never `ExitPlanMode` -- see
+ * `DesignCheckResult.openDesigns`'s doc comment. */
+export type DesignVerdict = "clean" | "overlap" | "constraint_flag" | "conflict" | "has_open_designs";
 
 /** 2026-08-19: an `overlap`/`constraint_flag` verdict is no longer
  * uniformly blocking -- `severity` says which of the two it is. `"warning"`
@@ -291,7 +300,10 @@ export interface DesignConflict {
 
 export interface DesignCheckResult {
   verdict: DesignVerdict;
-  designId: string;
+  /** Absent only for `"has_open_designs"` -- that verdict fires *before* a
+   * row is created (see DesignVerdict's own doc comment), so there is no id
+   * to report yet. Every other verdict always has one. */
+  designId?: string;
   conflicts?: DesignConflict[];
   /** Every constraint the checked scope matched (2026-08-22 -- was a single
    * `constraint` object; `matchConstraintsForPaths` used to collapse to one
@@ -302,6 +314,12 @@ export interface DesignCheckResult {
   constraints?: { id: string; statement: string; type: DesignConstraintType }[];
   /** See DesignSeverity. Undefined for `"clean"`. */
   severity?: DesignSeverity;
+  /** Set only for `"has_open_designs"` (2026-08-25) -- the developer's other
+   * currently-open designs, cross-project, that a plain `twing design
+   * register` call found before creating a new row. Lets the CLI print
+   * "here's what you already have open" without a second round trip. Never
+   * set for any other verdict. */
+  openDesigns?: { id: string; projectId: string; summary: string; lastActivityAt: number }[];
 }
 
 export interface PendingReview {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -537,7 +537,7 @@ test("GET /v1/activity: newest-first, respects ?limit=, ?before= pages backward,
     await app.request("/v1/designs/check", {
       method: "POST",
       headers: { "content-type": "application/json", ...bearer(admin.token) },
-      body: JSON.stringify({ projectId: "proj-1", sessionId: `s${i}`, summary: summaries[i], creates: [`f${i}.ts`], touches: [], dependsOn: [] }),
+      body: JSON.stringify({ projectId: "proj-1", sessionId: `s${i}`, summary: summaries[i], creates: [`f${i}.ts`], touches: [], dependsOn: [], force: true }),
     });
     await new Promise((resolve) => setTimeout(resolve, 2));
   }
@@ -573,9 +573,15 @@ test("GET /v1/activity: newest-first, respects ?limit=, ?before= pages backward,
   const pagedIds = [...firstBody.items, ...secondBody.items].map((e) => e.id).sort();
   assert.deepEqual(pagedIds, allBody.items.map((e) => e.id).sort());
 
+  // "Force a choice" registration-sprawl fix (2026-08-25): every call here
+  // uses the same developer and disjoint touches/creates, so from the 2nd
+  // call onward the broadened stale-sibling notice also fires once per
+  // already-open, non-overlapping prior design -- 0+1+2+3+4 = 10 extra
+  // design_stale_sibling_suggested events on top of the original 10
+  // (design_registered + design_checked, one pair per check call).
   const unfiltered = await app.request("/v1/activity?projectId=proj-1", { headers: bearer(admin.token) });
   const unfilteredBody = (await unfiltered.json()) as { items: unknown[] };
-  assert.equal(unfilteredBody.items.length, 10, "design_registered + design_checked, one pair per check call");
+  assert.equal(unfilteredBody.items.length, 20);
 
   const filteredOut = await app.request("/v1/activity?projectId=proj-1&kind=review_decided", { headers: bearer(admin.token) });
   assert.deepEqual(((await filteredOut.json()) as { items: unknown[] }).items, []);
@@ -1421,7 +1427,7 @@ test("GET /v1/designs: newest-first, optionally filtered by status/sessionId", a
     const res = await app.request("/v1/designs/check", {
       method: "POST",
       headers: { "content-type": "application/json", ...bearer(admin.token) },
-      body: JSON.stringify({ projectId: "proj-1", sessionId, summary: `design for ${sessionId}`, creates: [], touches, dependsOn: [] }),
+      body: JSON.stringify({ projectId: "proj-1", sessionId, summary: `design for ${sessionId}`, creates: [], touches, dependsOn: [], force: true }),
     });
     return (await res.json()) as { designId: string; verdict: string };
   };
@@ -1638,7 +1644,7 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
   assert.deepEqual(await inScope.json(), { state: "in_scope", designId });
 
   const outOfScope = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=z.ts`, { headers: bearer(admin.token) });
-  assert.deepEqual(await outOfScope.json(), { state: "out_of_scope", designId });
+  assert.deepEqual(await outOfScope.json(), { state: "out_of_scope", designId, openDesigns: [{ id: designId, summary: "" }] });
 
   // A constraint match (tier 3, error severity), not tier 1 exact overlap --
   // since the 2026-08-19 severity split tier 1 is "warning" severity and no
@@ -1651,7 +1657,7 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
   const flaggedRegisterRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["protected.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["protected.ts"], dependsOn: [], force: true }),
   });
   const { designId: flaggedId, verdict: flaggedVerdict } = (await flaggedRegisterRes.json()) as { designId: string; verdict: string };
   assert.equal(flaggedVerdict, "constraint_flag");
@@ -1671,6 +1677,43 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
 
   const flaggedAfterResolve = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s2&path=protected.ts`, { headers: bearer(admin.token) });
   assert.deepEqual(await flaggedAfterResolve.json(), { state: "flagged", designId: flaggedId, pendingReview: true });
+});
+
+// Found live (2026-08-25): with more than one open design in the same
+// session, out_of_scope used to hand back a single `designId` picked as
+// `openOnes[openOnes.length - 1]` -- since openOnes inherits listByProject's
+// newest-first order, that's the *oldest* open design, not the newest/most
+// likely one, and the hook had no way to see the others at all.
+test("GET /v1/designs/scope-match: out_of_scope with more than one open design in the session lists every one, newest-first, not just the oldest", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  const firstRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "oldest task", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId: firstId } = (await firstRes.json()) as { designId: string };
+
+  const secondRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newest task", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+  });
+  const { designId: secondId } = (await secondRes.json()) as { designId: string };
+
+  const outOfScope = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=z.ts`, { headers: bearer(admin.token) });
+  const body = (await outOfScope.json()) as { state: string; designId?: string; openDesigns?: { id: string; summary: string }[] };
+  assert.equal(body.state, "out_of_scope");
+  assert.equal(body.designId, secondId, "the single-designId hint must be the newest open design, not the oldest");
+  assert.deepEqual(
+    body.openDesigns,
+    [
+      { id: secondId, summary: "newest task" },
+      { id: firstId, summary: "oldest task" },
+    ],
+    "every open design for the session must be listed, newest-first",
+  );
 });
 
 test("GET /v1/designs/scope-match: with no ?path=, can only report no_design/flagged/in_scope (can't verify scope without a path)", async () => {
@@ -1721,7 +1764,7 @@ test("POST /v1/designs/check: a flagged design stays visible to a *third* design
   const secondRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "second", creates: [], touches: ["shared.ts", "constrained.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "second", creates: [], touches: ["shared.ts", "constrained.ts"], dependsOn: [], force: true }),
   });
   const secondBody = (await secondRes.json()) as { verdict: string; designId: string; severity?: string };
   assert.equal(secondBody.verdict, "constraint_flag");
@@ -1819,7 +1862,7 @@ test("POST /v1/designs/:id/amend: a groupId-only body joins a group after the fa
   const soloRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "was solo", creates: [], touches: ["b.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "was solo", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
   });
   const solo = (await soloRes.json()) as { designId: string; groupId?: string };
   assert.equal(solo.groupId, solo.designId, "starts as its own group of one");
@@ -1859,7 +1902,7 @@ test("POST /v1/designs/:id/amend: groupId passes through checkAmendedScope's del
   const targetRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "target", creates: [], touches: ["b.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "target", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
   });
   const target = (await targetRes.json()) as { designId: string; verdict: string };
   assert.equal(target.verdict, "clean", "sanity: unrelated projects/paths, nothing to conflict with");
@@ -1999,7 +2042,7 @@ test("POST /v1/designs/:id/amend: a rejected amend's proposed scope survives an 
   const registerRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [], force: true }),
   });
   const { designId } = (await registerRes.json()) as { designId: string };
 
@@ -2210,7 +2253,7 @@ test("POST /v1/designs/:id/amend: supersedes a still-running semantic-comparator
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(otherPat) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-other2", summary: "", creates: [], touches: ["other2.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-other2", summary: "", creates: [], touches: ["other2.ts"], dependsOn: [], force: true }),
   });
 
   let calls = 0;
@@ -2483,7 +2526,7 @@ test("POST /v1/designs/check: registering a non-overlapping design for the same 
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "unrelated second task", creates: [], touches: ["b.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "unrelated second task", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
   });
 
   const notices = await app.request("/v1/notices?since=0", { headers: bearer(admin.token) });
@@ -2507,7 +2550,7 @@ test("POST /v1/designs/check: an overlapping second design does not also fire th
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [], force: true }),
   });
 
   const notices = await app.request("/v1/notices?since=0", { headers: bearer(admin.token) });
@@ -2519,27 +2562,32 @@ test("POST /v1/designs/check: an overlapping second design does not also fire th
   );
 });
 
-test("POST /v1/designs/check: a non-overlapping design from a *different* session does not fire a stale-sibling notice", async () => {
+// "Force a choice" registration-sprawl fix (2026-08-25): the stale-sibling
+// nudge's sibling set was broadened from same-session to
+// openDesignsForDeveloper -- see app.ts's own comment on the exact spot.
+// This test previously asserted the opposite (cross-session siblings don't
+// fire); it now pins the new, intended behavior instead.
+test("POST /v1/designs/check: a non-overlapping design from a *different* session DOES now fire a stale-sibling notice (broadened, 2026-08-25)", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
 
-  await app.request("/v1/designs/check", {
+  const firstRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
   });
+  const { designId: firstId } = (await firstRes.json()) as { designId: string };
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["b.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
   });
 
   const notices = await app.request("/v1/notices?since=0", { headers: bearer(admin.token) });
   const noticesBody = (await notices.json()) as { items: { message: string }[] };
-  assert.equal(
-    noticesBody.items.filter((n) => n.message.includes("also have design")).length,
-    0,
-    "the nudge is scoped to same-session siblings only",
+  assert.ok(
+    noticesBody.items.some((n) => n.message.includes(firstId) && n.message.includes("also have design")),
+    "the nudge is developer-wide now, not scoped to same-session siblings",
   );
 });
 
@@ -2713,7 +2761,7 @@ test("POST /v1/designs/check: a structured (twing design register-style) call wi
   const second = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-cli", summary: "task one", creates: ["A"], touches: [], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-cli", summary: "task one", creates: ["A"], touches: [], dependsOn: [], force: true }),
   });
   const secondBody = (await second.json()) as { designId: string; verdict: string };
   assert.equal(second.status, 200);
@@ -2762,6 +2810,108 @@ test("POST /v1/designs/check: a reregistered design keeps its justifiedConstrain
   const secondBody = (await second.json()) as { designId: string; verdict: string };
   assert.equal(secondBody.designId, firstBody.designId, "same row reregistered");
   assert.equal(secondBody.verdict, "clean", "already-justified constraint must not be re-flagged after a mere retry");
+});
+
+// ---------------------------------------------------------------------------
+// "Force a choice" registration-sprawl fix (2026-08-25) -- POST
+// /v1/designs/check's pre-registration has_open_designs check.
+// ---------------------------------------------------------------------------
+
+test("POST /v1/designs/check: a structured register call blocks with has_open_designs when the developer already has another open design, and creates no row", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  const firstRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId: firstId } = (await firstRes.json()) as { designId: string };
+
+  const beforeCount = designs.listByProject("proj-1").length;
+  const secondRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "second, different project entirely", creates: [], touches: ["b.ts"], dependsOn: [] }),
+  });
+  assert.equal(secondRes.status, 200);
+  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string; openDesigns?: { id: string }[]; severity?: string };
+  assert.equal(secondBody.verdict, "has_open_designs");
+  assert.equal(secondBody.severity, "error");
+  assert.equal(secondBody.designId, undefined, "no row exists for this verdict yet");
+  assert.ok(secondBody.openDesigns?.some((d) => d.id === firstId));
+  assert.equal(designs.listByProject("proj-1").length, beforeCount, "no new row persisted anywhere");
+  assert.equal(designs.listByProject("proj-2").length, 0, "no new row persisted anywhere");
+});
+
+test("POST /v1/designs/check: a caller-supplied groupId skips the has_open_designs block", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  const firstRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId: firstId } = (await firstRes.json()) as { designId: string };
+
+  const secondRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "linked continuation", creates: [], touches: ["b.ts"], dependsOn: [], groupId: firstId }),
+  });
+  const secondBody = (await secondRes.json()) as { verdict: string; groupId?: string };
+  assert.notEqual(secondBody.verdict, "has_open_designs");
+  assert.equal(secondBody.groupId, firstId);
+});
+
+test("POST /v1/designs/check: force:true skips the has_open_designs block", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+
+  const secondRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "genuinely new", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+  });
+  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string };
+  assert.notEqual(secondBody.verdict, "has_open_designs");
+  assert.ok(secondBody.designId);
+});
+
+test("POST /v1/designs/check: an ExitPlanMode-shaped (rawPlanText) request is never blocked by has_open_designs, regardless of other open designs", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+
+  const secondRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({
+      projectId: "proj-2",
+      sessionId: "s-plan",
+      rawPlanText: "Add a debounce helper to src/ui/search-box.ts so keystrokes don't trigger a network call on every character.",
+      summary: "add debounce helper",
+      creates: [],
+      touches: ["src/ui/search-box.ts"],
+      dependsOn: [],
+    }),
+  });
+  assert.equal(secondRes.status, 200);
+  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string };
+  assert.notEqual(secondBody.verdict, "has_open_designs");
+  assert.ok(secondBody.designId);
 });
 
 // --- §17 Phase 4: no_auth mode ---

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -61,6 +61,12 @@ interface DesignCheckRequestBody {
   // link label. Optional: self-assigned server-side to this design's own
   // id when omitted. See DesignStatement.groupId (@twing/core).
   groupId?: string;
+  // "Force a choice" registration-sprawl fix (2026-08-25): explicit opt-out
+  // of the has-open-designs pre-registration check below, for a developer
+  // who's deliberately starting a genuinely new, unrelated design while
+  // another is still open. Like groupId, not identity-bearing -- just a
+  // caller-chosen override, never itself a source of authorization.
+  force?: boolean;
 }
 
 interface ResolveRequestBody {
@@ -856,6 +862,30 @@ export function createApp(options: CreateAppOptions = {}) {
         }
       }
     }
+    // "Force a choice" registration-sprawl fix (2026-08-25): before creating
+    // yet another open design, make sure the developer isn't just about to
+    // fragment work they already have open elsewhere. Deliberately scoped to
+    // exactly the structured `twing design register` path -- `ExitPlanMode`
+    // (rawPlanText) always registers unchanged; see this plan's own doc
+    // comment / commit message for why blocking it too would require
+    // guessing at a retry-safe auto-link the way an earlier version of this
+    // feature wrongly did. `groupId`/`force` are the two explicit escape
+    // hatches: a caller who already knows which existing design this
+    // continues, or one deliberately overriding, skips the check entirely.
+    // No row is created if this fires -- unlike overlap/constraint_flag,
+    // which register-then-flag, there's nothing yet worth flagging, so
+    // don't create the very clutter this exists to prevent.
+    if (!body.rawPlanText && !body.groupId && !body.force) {
+      const openForDeveloper = designs.openDesignsForDeveloper(identity.developerId, Date.now());
+      if (openForDeveloper.length > 0) {
+        return c.json({
+          verdict: "has_open_designs",
+          severity: "error",
+          openDesigns: openForDeveloper.map((d) => ({ id: d.id, projectId: d.projectId, summary: d.summary, lastActivityAt: d.lastActivityAt })),
+        });
+      }
+    }
+
     design ??= designs.register({
       projectId: body.projectId,
       developerId: identity.developerId,
@@ -923,24 +953,35 @@ export function createApp(options: CreateAppOptions = {}) {
 
     // §17 design lifecycle (2026-08): registering a new design is a much
     // faster, more precise signal of context-switch than any inactivity
-    // window -- if this session already has other open/flagged designs
-    // that this one genuinely doesn't overlap, nudge about it. Advisory
-    // only: nothing about the sibling's status/lastActivityAt changes here
-    // -- dormancy stays driven by inactivity alone, this is purely
-    // informational.
+    // window -- if this developer already has other open designs that this
+    // one genuinely doesn't overlap, nudge about it. Advisory only: nothing
+    // about the sibling's status/lastActivityAt changes here -- dormancy
+    // stays driven by inactivity alone, this is purely informational.
+    //
+    // Broadened 2026-08-25 ("force a choice" registration-sprawl fix) from
+    // `openDesigns(projectId, ...)` filtered to same-session, to
+    // `openDesignsForDeveloper` -- cross-project and no longer
+    // session-restricted (session-scoping was only ever load-bearing for an
+    // earlier, abandoned ExitPlanMode-blocking approach; see this feature's
+    // plan/commit message). This is `ExitPlanMode`'s entire half of that
+    // feature: it never blocks, it just gets a wider, more useful version of
+    // this same notice.
     //
     // Deliberately `pathsOverlap`, not `outcome.conflicts` (2026-08-22): a
-    // same-session sibling is the same developer by construction, and
+    // same-developer sibling is the same developer by construction, and
     // `outcome.conflicts` now excludes same-developer pairs entirely (see
     // design-checks.ts's top-of-file comment) -- reusing it here would make
     // every sibling look "non-overlapping" regardless of whether their
-    // scopes actually collide, a wrong message, not just a missed one.
-    const staleSiblings = open.filter((d) => d.sessionId === body.sessionId && !pathsOverlap(design, d));
+    // scopes actually collide, a wrong message, not just a missed one. A
+    // cross-project sibling is never path-comparable at all, so it always
+    // qualifies as "doesn't overlap" and always gets the notice.
+    const staleSiblings = designs.openDesignsForDeveloper(identity.developerId, Date.now(), design.id).filter((d) => !pathsOverlap(design, d));
     for (const sibling of staleSiblings) {
       const message =
         `twing design coordinator: you also have design ${sibling.id} [${sibling.status}] open ` +
         `("${sibling.summary || "no summary"}") that this new design doesn't touch. If that work is done, ` +
-        `close it: twing design close --id ${sibling.id}`;
+        `close it: twing design close --id ${sibling.id} -- or if it's the same effort, link them: ` +
+        `twing design amend --id ${design.id} --group ${sibling.id}`;
       activityLog.append({
         projectId: body.projectId,
         developerId: identity.developerId,
@@ -1321,7 +1362,21 @@ export function createApp(options: CreateAppOptions = {}) {
         designs.touch(hit.id);
         return c.json({ state: "in_scope", designId: hit.id });
       }
-      return c.json({ state: "out_of_scope", designId: openOnes[openOnes.length - 1].id });
+      // Found live (2026-08-25): with more than one open design for this
+      // session, this used to hand back `openOnes[openOnes.length - 1]` --
+      // since `openOnes` inherits `listByProject`'s newest-first order
+      // (design-store.ts), that's the *oldest* open design, not the most
+      // recently registered/active one. A single-candidate guess should at
+      // least guess the most likely one; `designId` here is now
+      // `openOnes[0]`, the newest. `openDesigns` is new -- every open
+      // candidate for this session (still newest-first), so the caller
+      // (the Go hook's deny message) can offer all of them instead of
+      // silently picking just one.
+      return c.json({
+        state: "out_of_scope",
+        designId: openOnes[0].id,
+        openDesigns: openOnes.map((d) => ({ id: d.id, summary: d.summary })),
+      });
     }
 
     const dormantOnes = sessionDesigns.filter((d) => d.status === "dormant");

--- a/packages/server/src/design-store.test.ts
+++ b/packages/server/src/design-store.test.ts
@@ -26,6 +26,36 @@ test("DesignRegistry: openDesigns excludes the candidate itself", () => {
   registry.stop();
 });
 
+test("DesignRegistry: openDesignsForDeveloper finds a developer's open design in a different project", () => {
+  const registry = freshRegistry();
+  registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "first", creates: ["X"], touches: [], dependsOn: [] });
+  const b = registry.register({ projectId: "p2", developerId: "d1", sessionId: "s2", summary: "second", creates: ["Y"], touches: [], dependsOn: [] });
+  // Different developer, different project -- must not show up.
+  registry.register({ projectId: "p3", developerId: "d2", sessionId: "s3", summary: "other dev", creates: ["Z"], touches: [], dependsOn: [] });
+  const open = registry.openDesignsForDeveloper("d1", Date.now());
+  assert.equal(open.length, 2);
+  assert.ok(open.some((d) => d.id === b.id));
+  registry.stop();
+});
+
+test("DesignRegistry: openDesignsForDeveloper excludes the given excludeId and non-open statuses", () => {
+  const registry = freshRegistry();
+  const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "a", creates: ["X"], touches: [], dependsOn: [] });
+  const b = registry.register({ projectId: "p2", developerId: "d1", sessionId: "s2", summary: "b", creates: ["Y"], touches: [], dependsOn: [] });
+  registry.close(b.id);
+  const open = registry.openDesignsForDeveloper("d1", Date.now(), a.id);
+  assert.equal(open.length, 0);
+  registry.stop();
+});
+
+test("DesignRegistry: openDesignsForDeveloper excludes expired (TTL-elapsed) designs", () => {
+  const registry = freshRegistry();
+  const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "a", creates: [], touches: [], dependsOn: [], ttlMs: 10 });
+  const open = registry.openDesignsForDeveloper("d1", a.createdAt + 1000);
+  assert.equal(open.length, 0);
+  registry.stop();
+});
+
 test("DesignRegistry: TTL expiry excludes designs past createdAt+ttlMs", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [], ttlMs: 10 });

--- a/packages/server/src/design-store.ts
+++ b/packages/server/src/design-store.ts
@@ -238,6 +238,33 @@ export class DesignRegistry {
     return rows.map(fromDesignRow);
   }
 
+  /** Every currently-*open* design for a developer, across every project
+   * (2026-08-25, "force a choice" registration-sprawl fix) -- the
+   * cross-project counterpart to `openDesigns` above, keyed by `developerId`
+   * instead of `projectId`. Deliberately `status = "open"` only, not `IN
+   * ("open", "flagged")` like `openDesigns` -- a flagged design already has
+   * its own review/justify flow demanding attention; it isn't "another open
+   * design" competing for a fresh registration decision. `dormant` stays
+   * excluded for the same reason it's excluded everywhere else in this
+   * class. Same `lastActivityAt + ttlMs > now` liveness check as
+   * `openDesigns`. `excludeId` excludes by design id (not session id --
+   * there's no session-scoping need here; see this feature's own plan/PR
+   * for why). */
+  openDesignsForDeveloper(developerId: string, now: number = Date.now(), excludeId?: string): DesignStatement[] {
+    const conditions = [
+      eq(designsTable.developerId, developerId),
+      eq(designsTable.status, "open"),
+      sql`${designsTable.lastActivityAt} + ${designsTable.ttlMs} > ${now}`,
+    ];
+    if (excludeId) conditions.push(sql`${designsTable.id} != ${excludeId}`);
+    const rows = this.db
+      .select()
+      .from(designsTable)
+      .where(and(...conditions))
+      .all() as DesignRow[];
+    return rows.map(fromDesignRow);
+  }
+
   /** §17 scope enforcement (2026-08): a design's own registration/amendment
    * verdict wasn't `clean` -- demote it out of "open" so it stops counting
    * as a usable design for the Edit/Write gate, without losing its id


### PR DESCRIPTION
Three related fixes for a developer/agent ending up with several open designs for what's really one continuous effort:

1. **Join-existing-design hint** — `noDesignReason()`'s deny message gets a third suggested action: check `design list --mine --status open` and `amend --group` into an existing design instead of always registering fresh. `design list` gains `--mine` (client-side filter by developerId).

2. **`has_open_designs` hard block** — `POST /v1/designs/check` now hard-blocks a structured (`twing design register`) registration with a new `has_open_designs` verdict when the developer already has other open designs anywhere, unless `--group` or `--force` is passed — no row is created on block. `ExitPlanMode` itself is deliberately never blocked (no flag surface for an explicit choice, and auto-linking risks silently mis-grouping unrelated work); instead the existing stale-sibling advisory notice is broadened from same-project/same-session to fully cross-project/cross-session via a new `DesignRegistry.openDesignsForDeveloper` store method.

3. **Out-of-scope multi-candidate fix** — `GET /v1/designs/scope-match`'s `out_of_scope` state used to hand back a single `designId` as the amend candidate, picked via `openOnes[openOnes.length - 1]` — since `openOnes` inherits `listByProject`'s newest-first order, that's actually the *oldest* open design in the session, not the newest/most likely one. Now returns every open design for the session (`openDesigns[]`, newest-first) and the hook's `outOfScopeReason` lists every candidate as its own amend command (capped at 5, with a "...and N more" pointer to `design list --mine` beyond that), instead of silently picking one.

446 TS tests + full Go suite passing, typecheck clean across all packages. Live-verified against a local `twing serve` instance (register/`--force`/`--group`/close/group-fan-out) and against the real out-of-scope deny path in this repo's own dogfooding session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
