### PR TITLE
Collapse the design-conflict model to four buckets (§17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,45 @@ closed** -- the edit is blocked, with a message saying exactly why, rather
 than silently letting it through. Turn it off deliberately with
 `TWING_DESIGN_GATE=off` or `twing design disable-gate`.
 
+### The four conflict buckets
+
+Every conflict a design can hit collapses into exactly one of four buckets.
+One principle decides who resolves each: **approval belongs to whoever's
+authority you'd be overriding.** Overriding your own peer's declared or
+actual work is yours to waive; overriding a project-wide rule someone else
+wrote isn't.
+
+| # | Bucket | Between | Blocking? | Resolved by | Sub-kinds |
+|---|---|---|---|---|---|
+| 1 | `constraint_violation` | one design vs. a fixed project rule (`.twing/twing.yml`'s `constraints:`) | yes | **admin** approves (`twing design reviews --decide`) | *(none -- `DesignConstraintType` is a single value, `"constraint"`)* |
+| 2 | `file_overlap` | two designs' *declared* plans (self-reported `creates`/`touches`), before either has written a line | no -- advisory only, never flags | nothing to resolve | *(none)* |
+| 3 | `symbol_conflict` | two designs' *actual edits* -- a real edit lands on a symbol another open design's owner also edited, declared as their own scope, or whose signature it silently broke | yes, whichever side(s) have an open design at the time | **self** -- `twing design resolve --justify` clears your own block immediately, no admin needed | `real_edit_collision` (both sides genuinely wrote to the same symbol), `scope_intrusion` (your edit landed inside another design's *declared* scope), `contract_break` (you changed a signature a caller/callee's design depends on) |
+| 4 | `llm_divergence` | two designs' *stated intent* -- judged by an LLM (Bedrock) on what each plan actually does, even when file lists never overlap | yes | **self**, same as `symbol_conflict` | `duplication` (same problem solved twice), `contradictory_assumptions` (one plan assumes true what the other assumes false), `tension` (the two plans' changes to shared behavior/data/contracts don't agree on which wins) |
+
+Implications of the split:
+
+- **Only bucket 1 ever needs a human.** Buckets 3 and 4 exist because two
+  peers' own work collided -- neither has more authority than the other, so
+  whichever side is blocked can justify and clear it themselves
+  (`resolve --justify` auto-decides "approve" the instant the review has no
+  constraint hit in it). A justification that *also* touches a constraint
+  hit stays admin-gated regardless of what else is bundled with it.
+- **Bucket 2 never blocks anything.** It's a plan-vs-plan heads-up before
+  either side has actually touched a file -- useful context, never a gate.
+  If it later becomes real (someone actually edits the shared symbol), that
+  shows up separately as a bucket-3 `symbol_conflict`.
+- **Buckets 1 and 3/4 differ in what they're checked against.** Bucket 1 is
+  deterministic (a `.twing/twing.yml` rule, checked synchronously). Buckets
+  3 and 4 are sourced from real signal -- Tree-sitter-parsed `Claim`s for
+  bucket 3, an async Bedrock semantic-conflict pass for bucket 4 -- so
+  either can arrive *after* the triggering `Edit`/`Write` already succeeded,
+  surfaced via `twing align` / an alignment thread rather than a synchronous
+  deny.
+- There's a fifth value, `has_open_designs`, that isn't a conflict between
+  two designs at all -- a pre-registration hygiene check ("you already have
+  too much of your own work open") that runs before any new design row
+  exists.
+
 ```sh
 twing design register --summary "adds a retry wrapper" --touches src/net/retry.ts
 twing design amend --id <designId> --touches src/net/retry-config.ts
@@ -120,9 +159,9 @@ closes one on demand, right when the work it named is finished, same as
 `resolve`/`amend` targeting one specific design by id. Safe to call more
 than once; closing an already-closed/superseded/expired design is a no-op.
 
-Constraints (the `canonical_abstraction`/`review_required` rules a design
-gets checked against, seeded from `.twing/twing.yml`'s `constraints:`
-section by `twing init`) are separate from designs -- `twing constraints
+Constraints (the project rules a design gets checked against for bucket 1
+above, seeded from `.twing/twing.yml`'s `constraints:` section by
+`twing init`) are separate from designs -- `twing constraints
 list` shows what's currently enforced for a project, and any project admin
 can `twing constraints remove --id <constraintId>` to retire a stale one
 immediately. This is deliberately *unilateral* -- one admin acting alone,
@@ -150,12 +189,16 @@ on a fresh session's very first deny, to check `twing design list --mine
 new one for it. Follow whichever it tells you, then retry the original
 edit. Two things worth knowing before you do:
 
-- **`resolve --justify` records a justification, it does not itself unblock
-  you.** It queues a `PendingReview` for a project admin to approve or
-  reject (`twing design reviews --decide`); until that happens, the same
-  file stays denied, now with a different message telling you a review is
-  pending rather than that nothing's registered. Don't loop retrying it --
-  that's a stop-and-wait state, not a self-serviceable one.
+- **`resolve --justify` unblocks you immediately for a `symbol_conflict` or
+  `llm_divergence` deny, but not for `constraint_violation`.** The two
+  peer-vs-peer buckets self-approve on the spot -- no one else's authority
+  is being overridden, so the tool call reports `status: "resolved"` and
+  the same edit succeeds on retry right away. A `constraint_violation`
+  justification instead queues a `PendingReview` for a project admin
+  (`twing design reviews --decide`); until that happens, the file stays
+  denied with a message saying a review is pending. Don't loop retrying it
+  in that case -- that's a stop-and-wait state, not a self-serviceable one.
+  See "The four conflict buckets" above for which is which.
 - **Tell the human what happened.** Registering, amending, or resuming a
   design creates a real record on the coordinator, attributed to the
   operator's own identity, that other sessions' conflict checks get

--- a/hook/design_gate.go
+++ b/hook/design_gate.go
@@ -182,12 +182,6 @@ type designCheckResponse struct {
 	// `Constraint` -- see design-checks.ts's matchConstraintsForPaths doc
 	// comment for why this is a list now).
 	Constraints []designConstraintInfo `json:"constraints,omitempty"`
-	// Severity (2026-08-19, design-checks.ts's severity split): "warning" |
-	// "error" | "" (empty on a "clean" verdict, where it's moot). Only an
-	// "error" verdict denies here -- a "warning" (currently tier 1's
-	// exactOverlap only) is display-only, same as "clean" as far as this
-	// gate is concerned. See DesignSeverity's doc comment in core/types.ts.
-	Severity string `json:"severity,omitempty"`
 	// GroupID (§17 design linking, 2026-08): echoes back the design's own
 	// groupId (self-assigned or caller-supplied). Not consumed by any
 	// gate decision today -- available for future logging/diagnostics.
@@ -195,10 +189,16 @@ type designCheckResponse struct {
 }
 
 // blocksGate reports whether this response's verdict should deny the tool
-// call. "clean" never blocks; a non-clean verdict blocks unless it's been
-// explicitly demoted to "warning" severity.
+// call. 2026-08-26: `Severity` is gone from the wire entirely -- blocking is
+// now a static function of `Verdict` alone (see DesignVerdict's doc comment,
+// core/types.ts). `/v1/designs/check`/`amend`/`resume` (design-checks.ts
+// tiers 1/3, the only source of a `designCheckResponse`) can only ever
+// return "clean", "file_overlap" (always advisory), or "constraint_violation"
+// (always blocks) -- anything else (e.g. "has_open_designs") falls through
+// to the caller's own "unknown verdict" fail-closed default, unchanged from
+// before this rename.
 func (r designCheckResponse) blocksGate() bool {
-	return r.Verdict != "clean" && r.Severity != "warning"
+	return r.Verdict != "clean" && r.Verdict != "file_overlap"
 }
 
 type designListResponse struct {
@@ -578,15 +578,14 @@ func handleExitPlanModeSingle(payload hookPayload, config twingConfig) {
 	case result.Verdict == "clean":
 		writeJSON(allowOutput("PreToolUse"))
 	case !result.blocksGate():
-		// 2026-08-19, severity split: an "overlap" verdict demoted to
-		// "warning" (tier 1's exactOverlap only, currently) registers and
-		// allows same as clean -- the conflict is still recorded server-side
-		// for display, just not gate-relevant. Only "overlap"/"error" and
-		// "constraint_flag" (always "error") reach the deny branch below.
+		// 2026-08-26: "file_overlap" (renamed from "overlap") is always
+		// advisory now -- registers and allows same as clean. The conflict
+		// is still recorded server-side for display, just never gate-relevant
+		// -- see DesignVerdict's doc comment, core/types.ts, for why blocking
+		// is now a static function of verdict alone with no separate
+		// severity to check.
 		writeJSON(allowOutput("PreToolUse"))
-	case result.Verdict == "overlap":
-		writeJSON(denyOutput("PreToolUse", overlapReason(result)))
-	case result.Verdict == "constraint_flag":
+	case result.Verdict == "constraint_violation":
 		writeJSON(denyOutput("PreToolUse", constraintReason(result)))
 	default:
 		logDesignGate("ExitPlanMode check: unknown verdict %q (blocking)", result.Verdict)
@@ -696,13 +695,10 @@ func handleExitPlanModeMultiCandidate(payload hookPayload) {
 			switch {
 			case result.Verdict == "clean", !result.blocksGate():
 				// no-op -- allowed overall unless something else denies.
-				// The second case is 2026-08-19's severity split: a
-				// "warning"-severity "overlap" (tier 1 only) registers and
-				// allows same as clean, same reasoning as the single-repo
-				// path above.
-			case result.Verdict == "overlap":
-				denyReasons = append(denyReasons, fmt.Sprintf("[%s] %s", cand.DirName, overlapReason(result)))
-			case result.Verdict == "constraint_flag":
+				// The second case is 2026-08-26: "file_overlap" (renamed from
+				// "overlap") always registers and allows, same as clean, same
+				// reasoning as the single-repo path above.
+			case result.Verdict == "constraint_violation":
 				denyReasons = append(denyReasons, fmt.Sprintf("[%s] %s", cand.DirName, constraintReason(result)))
 			default:
 				logDesignGate("ExitPlanMode multi-candidate check: unknown verdict %q for %s (blocking)", result.Verdict, cand.DirName)
@@ -907,36 +903,25 @@ func overlapReason(result designCheckResponse) string {
 	)
 }
 
-// constraintTypeText translates a constraint's machine type into something
-// a reader who has never opened .twing/twing.yml can act on.
-func constraintTypeText(t string) string {
-	switch t {
-	case "review_required":
-		return "a human must review changes here"
-	case "canonical_abstraction":
-		return "use the existing approach, don't add a second one"
-	case "domain_fact":
-		return "a fact about this codebase you should not contradict"
-	default:
-		return t
-	}
-}
-
 // constraintReason lists every matched constraint (2026-08-22, was a single
 // statement/type pair) -- mirrors overlapReason's own loop over
 // result.Conflicts just above it in this file, so a session sees every
 // violation from one ExitPlanMode call instead of discovering the next one
 // only after justifying and retrying.
+//
+// 2026-08-26: dropped the per-constraint `constraintTypeText(c.Type)`
+// parenthetical -- `DesignConstraintType` collapsed to a single value
+// ("constraint"), so there's no longer a type-specific phrase to pick
+// between (`review_required`/`canonical_abstraction`/`domain_fact` were
+// mechanically identical; see DesignVerdict's doc comment, core/types.ts).
+// The rule's own statement text already carries the substance.
 func constraintReason(result designCheckResponse) string {
 	details := []denyDetail{}
 	for i, c := range result.Constraints {
 		if i > 0 {
 			details = append(details, denyDetail{})
 		}
-		details = append(details,
-			denyDetail{"Rule", c.Statement},
-			denyDetail{"", "(" + constraintTypeText(c.Type) + ")"},
-		)
+		details = append(details, denyDetail{"Rule", c.Statement})
 	}
 
 	return denyMessage(
@@ -985,6 +970,12 @@ type designScopeMatchResponse struct {
 	// Both used to deny with the identical message telling you to run
 	// `twing design resolve`, even immediately after you already had.
 	PendingReview bool `json:"pendingReview,omitempty"`
+	// Set only for state "flagged" (2026-08-26 terminology simplification):
+	// true only when the flag came from "constraint_violation" -- the one
+	// bucket of the four that needs a project admin's decide. See
+	// flaggedDesignReason's own doc comment for the full branching this
+	// drives.
+	RequiresAdmin bool `json:"requiresAdmin,omitempty"`
 	// Set only for state "out_of_scope" (2026-08-25) -- every open design
 	// for this session, newest-first, not just the one `DesignID` names.
 	// Found live: with more than one open design in a session, silently
@@ -1045,18 +1036,48 @@ func checkDesignScope(serverURL, authToken, developerID, projectID, sessionID, f
 // wrong as of the async semantic comparator (2026-08-22): a design can be
 // flagged minutes after a clean registration, by runSemanticComparatorPass,
 // so the conflict frequently did not come from registration at all.
-func flaggedDesignReason(designID string, pendingReview bool) string {
+//
+// requiresAdmin (2026-08-26 terminology simplification): which of the four
+// buckets actually flagged this design -- only "constraint_violation" (one
+// design vs. a fixed project rule) needs a project admin's decide; a
+// "symbol_conflict"/"llm_divergence" flag (two designs vs. each other) is
+// self-approvable, so `twing design resolve --justify` clears it
+// immediately, no admin involved. See DesignVerdict's doc comment,
+// core/types.ts, for the full four-bucket model and "approval belongs to
+// whoever's authority you'd be overriding" principle this reflects. When
+// `pendingReview` is also true, `requiresAdmin` further distinguishes
+// "waiting on a person" from "already resolved, nothing more to do".
+func flaggedDesignReason(designID string, pendingReview bool, requiresAdmin bool) string {
 	if pendingReview {
+		if requiresAdmin {
+			return denyMessage(
+				"You're waiting on a person, not on twing.",
+				"Your explanation has been sent to a project admin. There's nothing more to do "+
+					"on your end -- retrying won't help until someone decides.",
+				[]denyDetail{{"Your plan", designID}, {"Status", "waiting for review"}},
+				[]denyAction{
+					{Label: "Check where it stands", Command: "twing design reviews"},
+					{Label: "Or ask a project admin to take a look"},
+				},
+			)
+		}
+		// A self-approvable bucket's justification is decided the instant
+		// it's submitted (`/v1/designs/:id/resolve`'s auto-decide branch) --
+		// this state should be momentary, not something a retry should ever
+		// actually observe. Kept as its own message rather than folded into
+		// the "not yet justified" one below, in case of a race between the
+		// deny and the resolve call actually landing.
 		return denyMessage(
-			"You're waiting on a person, not on twing.",
-			"Your explanation has been sent to a project admin. There's nothing more to do "+
-				"on your end -- retrying won't help until someone decides.",
-			[]denyDetail{{"Your plan", designID}, {"Status", "waiting for review"}},
-			[]denyAction{
-				{Label: "Check where it stands", Command: "twing design reviews"},
-				{Label: "Or ask a project admin to take a look"},
-			},
+			"Your justification is still being processed.",
+			"This is self-approvable -- no admin needed. If this doesn't clear on the next "+
+				"try, something went wrong.",
+			[]denyDetail{{"Your plan", designID}, {"Status", "resolving"}},
+			[]denyAction{{Label: "Retry your edit"}},
 		)
+	}
+	note := "This is self-approvable -- you'll be unblocked as soon as you submit it, no admin needed."
+	if requiresAdmin {
+		note = "This goes to a project admin. You stay blocked until they decide."
 	}
 	return denyMessage(
 		"Someone else may already be doing this work.",
@@ -1071,7 +1092,7 @@ func flaggedDesignReason(designID string, pendingReview bool) string {
 			{
 				Label:   "Or explain why yours needs to be separate",
 				Command: fmt.Sprintf("twing design resolve --id %s --justify \"<reason>\"", designID),
-				Note:    "This goes to a project admin. You stay blocked until they decide.",
+				Note:    note,
 			},
 		},
 	)
@@ -1269,14 +1290,14 @@ func checkPathConstraint(serverURL, authToken, developerID, projectID, sessionID
 // Lists every matched constraint (2026-08-22, was a single statement/type
 // pair) -- a file covered by several rules at once should deny with all of
 // them named up front, not reveal the next one only after a retry.
+//
+// 2026-08-26: same `constraintTypeText` drop as constraintReason above --
+// `DesignConstraintType` collapsed to a single value, so there's no
+// type-specific phrase left to append.
 func pathConstraintReason(filePath string, constraints []designConstraintInfo) string {
 	details := []denyDetail{{"File", filePath}}
 	for _, c := range constraints {
-		details = append(details,
-			denyDetail{},
-			denyDetail{"Rule", c.Statement},
-			denyDetail{"", "(" + constraintTypeText(c.Type) + ")"},
-		)
+		details = append(details, denyDetail{}, denyDetail{"Rule", c.Statement})
 	}
 
 	return denyMessage(
@@ -1392,7 +1413,7 @@ func handleEditWriteGate(payload hookPayload) {
 	case "in_scope":
 		writeJSON(allowOutput("PreToolUse"))
 	case "flagged":
-		writeJSON(denyOutput("PreToolUse", flaggedDesignReason(scopeMatch.DesignID, scopeMatch.PendingReview)))
+		writeJSON(denyOutput("PreToolUse", flaggedDesignReason(scopeMatch.DesignID, scopeMatch.PendingReview, scopeMatch.RequiresAdmin)))
 	case "dormant":
 		writeJSON(denyOutput("PreToolUse", dormantDesignReason(scopeMatch.DesignID, scopeMatch.Summary, scopeMatch.DormantSinceMs)))
 	case "out_of_scope":

--- a/hook/design_gate_test.go
+++ b/hook/design_gate_test.go
@@ -656,13 +656,13 @@ func TestHandleExitPlanModeSingle_NeverSetsGroupID(t *testing.T) {
 	}
 }
 
-// 2026-08-19 severity split (design-checks.ts): a "warning"-severity
-// "overlap" verdict (tier 1's exactOverlap only, currently) registers and
-// allows same as clean -- the conflict is still recorded server-side for
-// display, just not gate-relevant.
-func TestHandleExitPlanMode_OverlapWarningSeverity_Allows(t *testing.T) {
+// 2026-08-26 terminology simplification: blocking is a pure function of
+// verdict now -- file_overlap (tier 1's exactOverlap) never blocks, full
+// stop, no severity field to consult at all. The conflict is still recorded
+// server-side for display, just not gate-relevant.
+func TestHandleExitPlanMode_FileOverlap_Allows(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"verdict":"overlap","severity":"warning","designId":"d1","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"touches","overlapDetail":"both touch shared.ts","conflictingSummary":"another session's work"}]}`))
+		_, _ = w.Write([]byte(`{"verdict":"file_overlap","designId":"d1","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"touches","overlapDetail":"both touch shared.ts","conflictingSummary":"another session's work"}]}`))
 	}))
 	defer server.Close()
 
@@ -676,13 +676,12 @@ func TestHandleExitPlanMode_OverlapWarningSeverity_Allows(t *testing.T) {
 	}
 }
 
-// Companion to the warning-severity test above -- an "overlap" verdict with
-// no severity field at all (today's original response shape, still valid
-// for tier 4/constraint_flag, and any coordinator not yet upgraded) must
-// still deny, same as before this split.
-func TestHandleExitPlanMode_OverlapNoSeverity_StillDenies(t *testing.T) {
+// Companion to the test above -- a stray legacy "severity" field (an older
+// coordinator, or one not yet upgraded off the pre-2026-08-26 shape) must be
+// ignored rather than reintroducing severity-based branching.
+func TestHandleExitPlanMode_FileOverlap_IgnoresStraySeverityField(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"verdict":"overlap","designId":"d1","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"touches","overlapDetail":"summaries are 80% similar","conflictingSummary":"another session's work"}]}`))
+		_, _ = w.Write([]byte(`{"verdict":"file_overlap","severity":"warning","designId":"d1","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"touches","overlapDetail":"summaries are 80% similar","conflictingSummary":"another session's work"}]}`))
 	}))
 	defer server.Close()
 
@@ -691,8 +690,8 @@ func TestHandleExitPlanMode_OverlapNoSeverity_StillDenies(t *testing.T) {
 
 	stdout := captureStdout(t, func() { handleExitPlanMode(planPayload(repo, "sess1")) })
 	decision, _ := decisionOf(t, stdout)
-	if decision != "deny" {
-		t.Fatalf("decision = %q, want deny", decision)
+	if decision != "allow" {
+		t.Fatalf("decision = %q, want allow", decision)
 	}
 }
 
@@ -938,7 +937,10 @@ func TestHandleExitPlanMode_MultiCandidate_NoCandidatesAtAll_SilentNoOp(t *testi
 }
 
 // A denial from one matched candidate must still surface, naming which repo
-// it came from, even though the other candidate came back clean.
+// it came from. 2026-08-26: rewritten from an "overlap" fixture to
+// "constraint_violation" -- the only verdict that still blocks and denies
+// via constraintReason here (file_overlap never blocks at all now, see the
+// multi-candidate switch in handleExitPlanModeMultiCandidate).
 func TestHandleExitPlanMode_MultiCandidate_OneCandidateDenies_OverallDenies(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
@@ -949,7 +951,7 @@ func TestHandleExitPlanMode_MultiCandidate_OneCandidateDenies_OverallDenies(t *t
 			var body designCheckRequest
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if len(body.Touches) == 1 && body.Touches[0] == "src/Inbox.tsx" {
-				_, _ = w.Write([]byte(`{"verdict":"overlap","designId":"d2","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"exact_overlap","overlapDetail":"src/Inbox.tsx","conflictingSummary":"another session's inbox work"}]}`))
+				_, _ = w.Write([]byte(`{"verdict":"constraint_violation","designId":"d2","constraints":[{"statement":"protected inbox path","type":"constraint"}]}`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"verdict":"clean","designId":"d1"}`))
@@ -965,16 +967,16 @@ func TestHandleExitPlanMode_MultiCandidate_OneCandidateDenies_OverallDenies(t *t
 	if decision != "deny" {
 		t.Fatalf("decision = %q, want deny", decision)
 	}
-	if !strings.Contains(reason, "twinmail-ui") || !strings.Contains(reason, "d-other") {
-		t.Errorf("reason = %q, want it to name twinmail-ui and the conflicting design", reason)
+	if !strings.Contains(reason, "twinmail-ui") || !strings.Contains(reason, "protected inbox path") {
+		t.Errorf("reason = %q, want it to name twinmail-ui and the violated rule", reason)
 	}
 }
 
-// 2026-08-19 severity split, multi-candidate counterpart to
-// TestHandleExitPlanMode_OverlapWarningSeverity_Allows: one candidate comes
-// back "overlap"/"warning" -- must not deny overall, same as if it had come
-// back clean.
-func TestHandleExitPlanMode_MultiCandidate_OneCandidateWarningSeverity_OverallAllows(t *testing.T) {
+// 2026-08-26 terminology simplification, multi-candidate counterpart to
+// TestHandleExitPlanMode_FileOverlap_Allows: one candidate comes back
+// "file_overlap" -- must not deny overall, same as if it had come back
+// clean, since file_overlap never blocks regardless of any other candidate.
+func TestHandleExitPlanMode_MultiCandidate_OneCandidateFileOverlap_OverallAllows(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		switch r.URL.Path {
@@ -984,7 +986,7 @@ func TestHandleExitPlanMode_MultiCandidate_OneCandidateWarningSeverity_OverallAl
 			var body designCheckRequest
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if len(body.Touches) == 1 && body.Touches[0] == "src/Inbox.tsx" {
-				_, _ = w.Write([]byte(`{"verdict":"overlap","severity":"warning","designId":"d2","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"touches","overlapDetail":"src/Inbox.tsx","conflictingSummary":"another session's inbox work"}]}`))
+				_, _ = w.Write([]byte(`{"verdict":"file_overlap","designId":"d2","conflicts":[{"conflictingDesignId":"d-other","overlapKind":"touches","overlapDetail":"src/Inbox.tsx","conflictingSummary":"another session's inbox work"}]}`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"verdict":"clean","designId":"d1"}`))
@@ -1045,8 +1047,9 @@ func allDenyMessages(t *testing.T) map[string]string {
 	}
 	return map[string]string{
 		"noDesign":           noDesignReason(),
-		"flagged":            flaggedDesignReason("11111111-2222-3333-4444-555555555555", false),
-		"flaggedPendingRev":  flaggedDesignReason("11111111-2222-3333-4444-555555555555", true),
+		"flagged":            flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, true),
+		"flaggedPendingRev":  flaggedDesignReason("11111111-2222-3333-4444-555555555555", true, true),
+		"flaggedSelfApprove": flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, false),
 		"outOfScope":         outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts", nil),
 		"outOfScopeMulti": outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts", []designSummary{
 			{ID: "11111111-2222-3333-4444-555555555555", Summary: "add retry with backoff"},
@@ -1142,7 +1145,7 @@ func TestAuthRejectedReason_DistinguishesUnauthorizedFromForbidden(t *testing.T)
 // registration, so the old "conflict from its own registration" wording was
 // simply false in the common case.
 func TestFlaggedDesignReason_DoesNotClaimConflictCameFromRegistration(t *testing.T) {
-	msg := flaggedDesignReason("11111111-2222-3333-4444-555555555555", false)
+	msg := flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, true)
 	if strings.Contains(msg, "registration") {
 		t.Errorf("should not attribute the conflict to registration time: %q", msg)
 	}
@@ -1200,6 +1203,10 @@ func TestDenyOutput_SeparatesAgentNoteFromUserText(t *testing.T) {
 // only by driving the real binary against a real coordinator. This asserts
 // both, so a third one can't hide the same way.
 func TestBothConstraintPaths_LeadWithPlainSentence(t *testing.T) {
+	// Type is still accepted on the wire (backward compat) but 2026-08-26
+	// dropped constraintTypeText's per-type phrase entirely -- there's only
+	// one DesignConstraintType value now, so the rule's own statement text
+	// is what carries the substance, not a type-derived phrase.
 	rules := []designConstraintInfo{{Statement: "money paths need a second pair of eyes", Type: "review_required"}}
 
 	planPath := constraintReason(designCheckResponse{DesignID: "11111111-2222-3333-4444-555555555555", Constraints: rules})
@@ -1213,8 +1220,11 @@ func TestBothConstraintPaths_LeadWithPlainSentence(t *testing.T) {
 		if !strings.Contains(msg, "What now") {
 			t.Errorf("%s: no 'What now' section", name)
 		}
-		if !strings.Contains(msg, "a human must review changes here") {
-			t.Errorf("%s: constraint type not translated to plain language", name)
+		if !strings.Contains(msg, "money paths need a second pair of eyes") {
+			t.Errorf("%s: the rule's own statement text is missing", name)
+		}
+		if strings.Contains(msg, "review_required") {
+			t.Errorf("%s: raw constraint type leaked into the message untranslated: %q", name, msg)
 		}
 	}
 

--- a/packages/cli/src/align.ts
+++ b/packages/cli/src/align.ts
@@ -148,7 +148,16 @@ interface AlignmentThreadJSON {
   developerId: string;
   otherDeveloperId: string;
   systemDescription: string;
+  /** 2026-08-26: `"symbol_conflict" | "llm_divergence"` on any row created
+   * after the terminology simplification -- one of the old four values
+   * (`duplication`/`contradictory_assumptions`/`tension`/`symbol_claim`) on
+   * a row that predates it, never backfilled. See `subKind` below for the
+   * detail a pre-simplification row carried directly in this field. */
   category?: string;
+  /** Detail label under `category` -- absent on any row that predates the
+   * 2026-08-26 column. See AlignmentSubKind's own doc comment
+   * (alignment-store.ts). */
+  subKind?: string;
 }
 
 export async function runAlignThreads(options: AlignThreadsOptions): Promise<void> {
@@ -177,13 +186,18 @@ export async function runAlignThreads(options: AlignThreadsOptions): Promise<voi
     // category tag, which also restores info this line lost for a
     // semantic-conflict thread once the old symbolId-as-design-id stand-in
     // hack was removed server-side.
-    const categoryTag = t.category ? `  [${t.category}]` : "";
+    // 2026-08-26: `category` alone lost the detail it used to carry
+    // directly (four values collapsed to two bucket names) -- append
+    // `subKind` when present so a new-format row prints exactly as much
+    // information as an old-format row did.
+    const categoryTag = t.category ? `  [${t.category}${t.subKind ? `/${t.subKind}` : ""}]` : "";
     console.log(`${t.id}  [${t.status}]${categoryTag}  ${t.developerId} <-> ${t.otherDeveloperId}`);
     console.log(`  ${t.systemDescription}`);
     // Every accumulated overlapping file, not just the frozen first one --
-    // only worth a line once there's more than one to show.
+    // only worth a line once there's more than one to show. `symbol_claim`
+    // is the pre-2026-08-26 name for what's now `symbol_conflict`.
     const symbolIds = t.symbolIds ?? [];
-    if (t.category === "symbol_claim" && symbolIds.length > 1) {
+    if ((t.category === "symbol_conflict" || t.category === "symbol_claim") && symbolIds.length > 1) {
       console.log(`  files: ${symbolIds.join(", ")}`);
     }
   }

--- a/packages/cli/src/constraints.test.ts
+++ b/packages/cli/src/constraints.test.ts
@@ -17,7 +17,7 @@ const PROJECT_ID = "proj-1";
 
 test("runConstraintsList: appends ?projectId= and prints one line per constraint", async () => {
   const { fetch, calls } = captureFetch(
-    jsonResponse({ items: [{ id: "c1", type: "canonical_abstraction", statement: "use pkg/retry", scope: ["src/**"] }] }),
+    jsonResponse({ items: [{ id: "c1", type: "constraint", statement: "use pkg/retry", scope: ["src/**"] }] }),
   );
   await withHome(async () => {
     cacheToken(SERVER_URL, "test-token");

--- a/packages/cli/src/constraints.ts
+++ b/packages/cli/src/constraints.ts
@@ -43,8 +43,12 @@ export async function runConstraintsList(options: ConstraintsListOptions): Promi
     return;
   }
   const body = (await res.json()) as { items?: ConstraintJSON[] };
+  // 2026-08-26: dropped the `[${c.type}]` bracket -- DesignConstraintType
+  // collapsed to a single value ("constraint"), so it no longer carries any
+  // information worth printing. See DesignVerdict's doc comment,
+  // core/types.ts, for the collapse rationale.
   for (const c of body.items ?? []) {
-    console.log(`${c.id}  [${c.type}]  ${c.statement}  scope=${c.scope.join(",")}`);
+    console.log(`${c.id}  ${c.statement}  scope=${c.scope.join(",")}`);
   }
 }
 

--- a/packages/cli/src/design.test.ts
+++ b/packages/cli/src/design.test.ts
@@ -162,7 +162,6 @@ test("runDesignRegister: a has_open_designs verdict lists the other open designs
   const { fetch } = captureFetch(
     jsonResponse({
       verdict: "has_open_designs",
-      severity: "error",
       openDesigns: [{ id: "d-old", projectId: "proj-x", summary: "an older, still-open task", lastActivityAt: 1 }],
     }),
   );
@@ -237,7 +236,7 @@ test("runDesignClose: throws without --id", async () => {
 test("runDesignAmend: sends the split scope delta and prints conflict detail on overlap", async () => {
   const { fetch, calls } = captureFetch(
     jsonResponse({
-      verdict: "overlap",
+      verdict: "file_overlap",
       designId: "d1",
       conflicts: [{ conflictingDesignId: "d2", overlapKind: "touches", overlapDetail: "both touch b.ts", conflictingSummary: "someone else's work" }],
     }),

--- a/packages/cli/src/design.ts
+++ b/packages/cli/src/design.ts
@@ -54,7 +54,15 @@ interface DesignConflictJSON {
 
 interface DesignCheckResponseJSON {
   error?: string;
-  verdict?: "clean" | "overlap" | "constraint_flag" | "has_open_designs";
+  /** 2026-08-26 terminology simplification: renamed from
+   * `"clean" | "overlap" | "constraint_flag" | "has_open_designs"`. Only
+   * `"file_overlap"` and `"constraint_violation"` can come back from
+   * `/v1/designs/check`/`amend`/`resume` (design-checks.ts tiers 1/3);
+   * `"symbol_conflict"`/`"llm_divergence"` only ever arise from
+   * `/v1/claims` or the async semantic-comparator pass, never this
+   * synchronous response. See DesignVerdict's own doc comment,
+   * core/types.ts, for the full four-bucket model. */
+  verdict?: "clean" | "file_overlap" | "constraint_violation" | "has_open_designs";
   /** Absent only for `"has_open_designs"` -- that verdict fires before any
    * row is created. See DesignVerdict's own doc comment in core/types.ts. */
   designId?: string;
@@ -67,10 +75,6 @@ interface DesignCheckResponseJSON {
    * `constraint` object -- see design-checks.ts's matchConstraintsForPaths
    * doc comment for the full reasoning). */
   constraints?: { statement: string; type: string }[];
-  /** 2026-08-19 severity split -- "warning" (tier 1's exactOverlap only,
-   * currently) is display-only, undefined/"error" means today's original
-   * blocking behavior. See DesignSeverity's doc comment in core/types.ts. */
-  severity?: "warning" | "error";
   /** Set only for `"has_open_designs"` (2026-08-25, "force a choice"
    * registration-sprawl fix) -- the developer's other currently-open
    * designs, cross-project, found before this registration was created. */
@@ -89,33 +93,27 @@ function printDesignVerdict(result: DesignCheckResponseJSON): void {
   }
   // "has_open_designs" (2026-08-25) has no designId -- no row exists yet
   // for this verdict, see DesignCheckResult.designId's own doc comment.
-  console.log(
-    `verdict: ${result.verdict}${result.severity ? ` (${result.severity})` : ""}` + (result.designId ? `  design: ${result.designId}` : ""),
-  );
+  console.log(`verdict: ${result.verdict}` + (result.designId ? `  design: ${result.designId}` : ""));
   if (result.groupId) {
     // §17 design linking (2026-08): the copy-paste hint for linking a
     // sibling-repo registration to this one.
     console.log(`  group: ${result.groupId}  (registering a linked design in another repo? pass --group ${result.groupId})`);
   }
-  if (result.verdict === "overlap" && result.severity === "warning") {
-    // Display-only (2026-08-19 severity split): recorded for visibility,
-    // design stays open, no action required.
+  // 2026-08-26: blocking is now a static function of `verdict` alone --
+  // `"file_overlap"` (renamed from `"overlap"`) is always advisory-only,
+  // `"constraint_violation"` (renamed from `"constraint_flag"`) always
+  // blocks. No more severity branch to check within a single verdict.
+  if (result.verdict === "file_overlap") {
     for (const c of result.conflicts ?? []) {
       console.log(`  [${c.overlapKind}] conflicts with ${c.conflictingDesignId}: ${c.overlapDetail}`);
       console.log(`    their summary: ${c.conflictingSummary}`);
     }
-    console.log(`  (warning only -- no action needed; visible in the dashboard's design detail/activity feed)`);
-  } else if (result.verdict === "overlap") {
-    for (const c of result.conflicts ?? []) {
-      console.log(`  [${c.overlapKind}] conflicts with ${c.conflictingDesignId}: ${c.overlapDetail}`);
-      console.log(`    their summary: ${c.conflictingSummary}`);
-    }
-    console.log(`  -> adopt the existing design, or run: twing design resolve --id ${result.designId} --justify "<reason>"`);
-  } else if (result.verdict === "constraint_flag") {
+    console.log(`  (advisory only -- no action needed; visible in the dashboard's design detail/activity feed)`);
+  } else if (result.verdict === "constraint_violation") {
     for (const c of result.constraints ?? []) {
       console.log(`  [${c.type}] ${c.statement}`);
     }
-    console.log(`  -> adjust your plan, or run: twing design resolve --id ${result.designId} --justify "<reason>"`);
+    console.log(`  -> adjust your plan, or run: twing design resolve --id ${result.designId} --justify "<reason>" (a project admin will need to approve)`);
   } else if (result.verdict === "has_open_designs") {
     // "Force a choice" registration-sprawl fix (2026-08-25): no row was
     // created for this call -- nothing to point `resolve`/`close` at yet.
@@ -251,7 +249,21 @@ export async function runDesignResolve(options: ResolveOptions): Promise<void> {
     authToken,
     developerId,
   );
-  console.log(JSON.stringify(await parseJsonOrUnauthorized(res), null, 2));
+  const result = (await parseJsonOrUnauthorized(res)) as { error?: string; status?: string; reviewId?: string };
+  // 2026-08-26 self-approve: `/v1/designs/:id/resolve` now distinguishes
+  // "resolved" (no constraint hit in the mix -- decided immediately, the
+  // design is unblocked right now) from "pending_review" (a constraint
+  // violation is in the mix -- the only bucket where a project admin's
+  // decide is still required). See DesignVerdict's doc comment,
+  // core/types.ts, for the full four-bucket model this line reflects.
+  if (!result.error) {
+    if (result.status === "resolved") {
+      console.log(`twing design: unblocked -- self-approved, no admin needed (review ${result.reviewId}).`);
+    } else if (result.status === "pending_review") {
+      console.log(`twing design: waiting on a project admin -- run \`twing design reviews --decide ${result.reviewId} --decision approve\` (as an admin) to unblock.`);
+    }
+  }
+  console.log(JSON.stringify(result, null, 2));
 }
 
 export interface CloseOptions {

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -222,8 +222,10 @@ test("runInit: seeds constraints and require_human_review rules when the manifes
     assert.match(calls[0].url, /\/v1\/constraints\/seed$/);
     const body = calls[0].body as { constraints: { statement: string; type: string }[] };
     assert.equal(body.constraints.length, 2);
-    assert.ok(body.constraints.some((c) => c.type === "canonical_abstraction"));
-    assert.ok(body.constraints.some((c) => c.type === "review_required"));
+    // 2026-08-26: `type` collapsed to a single value ("constraint") for both
+    // the manifest's `constraints:` entries and its `require_human_review:`
+    // entries -- see DesignVerdict's doc comment, core/types.ts.
+    assert.ok(body.constraints.every((c) => c.type === "constraint"));
     assert.ok(logs.some((l) => l.includes("seeded 2 constraint(s)")));
   });
 });

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -303,8 +303,13 @@ async function seedConstraints(repoRoot: string, manifest: Manifest, serverUrl: 
           githubOwner: github?.owner,
           githubRepo: github?.repo,
           constraints: [
-            ...manifest.constraints.map((c) => ({ statement: c.text, scope: [c.scope], type: "canonical_abstraction" })),
-            ...reviewRules.map((r) => ({ statement: r.reason, scope: [(r.path ?? r.symbol)!], type: "review_required" })),
+            // 2026-08-26: `type` collapsed to the single value "constraint"
+            // -- `canonical_abstraction`/`review_required` never had a real
+            // behavioral difference (see DesignVerdict's doc comment in
+            // core/types.ts). Still sent on the wire since the server
+            // accepts (but no longer branches on) it.
+            ...manifest.constraints.map((c) => ({ statement: c.text, scope: [c.scope], type: "constraint" as const })),
+            ...reviewRules.map((r) => ({ statement: r.reason, scope: [(r.path ?? r.symbol)!], type: "constraint" as const })),
           ],
         }),
       },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -217,17 +217,39 @@ export interface DesignStatement {
    * a separate decision on that design's own row, if it ever comes up. */
   justifiedOverlaps: string[];
   /** Semantic comparator's counterpart to `justifiedOverlaps` above
-   * (2026-08-22) -- entries are bare `conflictingDesignId`s (no paths: a
-   * `"conflict"` verdict has no path evidence to key on, see
+   * (2026-08-22) -- entries are bare `conflictingDesignId`s (no paths: an
+   * `"llm_divergence"` verdict has no path evidence to key on, see
    * DesignVerdict's doc comment), so `runSemanticComparatorPass` skips
    * re-checking (and re-flagging) a pair once its conflict has been
    * justified and approved. Appended (never removed) by
    * `DesignRegistry.decideReview` when a review carrying
    * `conflictWaivers` is approved -- see `PendingReview.conflictWaivers`. */
   justifiedConflicts: string[];
+  /** `"symbol_conflict"`'s own approval memory (2026-08-26) -- same
+   * composite-key shape as `justifiedOverlaps` (`${conflictingDesignId}::${symbolId}`,
+   * via `overlapWaiverKey`), but kept as its own field rather than folded
+   * into `justifiedOverlaps`: a `file_overlap` warning (row 2, always
+   * advisory, self-reported scope) and a `symbol_conflict` block (row 3,
+   * always blocking, real edits) are philosophically different waivers
+   * even though the key shape coincides -- keeping them separate means a
+   * row-2 warning's justification history never gets conflated with a
+   * row-3 block's. Appended (never removed) by `DesignRegistry.decideReview`
+   * when a review carrying `symbolConflictWaivers` is approved -- see
+   * `PendingReview.symbolConflictWaivers`. */
+  justifiedSymbolConflicts: string[];
 }
 
-export type DesignConstraintType = "canonical_abstraction" | "domain_fact" | "review_required";
+/** 2026-08-26 terminology simplification: collapsed from a three-way
+ * `"canonical_abstraction" | "domain_fact" | "review_required"` union to a
+ * single value. Checked against every reader in the codebase (matching,
+ * severity, blocking, the admin-justify resolution flow) and found they
+ * treated all three identically -- the only thing `type` ever changed was
+ * which one-line phrase a deny message printed. The field stays on the wire
+ * (rather than being removed outright) specifically to avoid repeating the
+ * cross-repo break recorded for the `constraints` payload key rename
+ * (twing-monitor reads response shapes this repo doesn't control) -- only
+ * the number of values it can take collapses, not its presence. */
+export type DesignConstraintType = "constraint";
 
 export interface DesignConstraint {
   id: string;
@@ -241,46 +263,62 @@ export interface DesignConstraint {
   createdAt: number;
 }
 
-/** `"conflict"` (2026-08-22): the semantic comparator's own verdict
- * (design-semantic-check.ts's `checkSemanticConflict`, driven by app.ts's
- * `runSemanticComparatorPass`) -- an LLM judgment that two designs conflict
- * in intent, as opposed to `"overlap"`'s exact-path/keyword matching.
- * Distinct from `"overlap"` because it has different evidence (LLM
- * reasoning over free text, not paths) and a different justification shape
- * (see DesignStatement.justifiedConflicts / PendingReview.conflictWaivers,
- * keyed by conflicting design id alone, no paths -- there's nothing
- * path-shaped to waive). Never returned by `runDesignChecks`/
- * `DesignCheckResult` (design-checks.ts's tiers 1-4 run synchronously
- * against the request that triggered them); only ever set via
- * `DesignRegistry.flag()` from the async comparator pass, after its
- * response has already been sent.
+/**
+ * The four-bucket design-conflict model (2026-08-26 terminology
+ * simplification, superseding the prior five-verdict/severity/
+ * three-constraint-type/separate-align-vocabulary sprawl -- see
+ * docs/design-terminology.md and this repo's own memory of the design
+ * discussion that produced it). One principle: approval belongs to
+ * whoever's authority you'd be overriding.
  *
- * `"has_open_designs"` (2026-08-25): a pre-registration check, distinct from
- * the tiers above in that it runs *before* any row exists for this request
- * at all -- `overlap`/`constraint_flag`/`conflict` all presuppose a design
- * was already created and are about that design's relationship to others;
- * this one is about whether registration should even proceed. Only reachable
- * from `POST /v1/designs/check`'s structured (non-`rawPlanText`) path, i.e.
- * `twing design register`, never `ExitPlanMode` -- see
- * `DesignCheckResult.openDesigns`'s doc comment. */
-export type DesignVerdict = "clean" | "overlap" | "constraint_flag" | "conflict" | "has_open_designs";
+ * - `"file_overlap"`: two designs' *declared* plans (self-reported
+ *   `creates`/`touches`) name the same file, before either has written a
+ *   line. Always advisory -- never blocks, never flags, nothing to
+ *   resolve. (Was `"overlap"` tier 1; tier 4's Jaccard summary-similarity
+ *   fallback is dropped entirely as of this change, redundant with
+ *   `"llm_divergence"` below.)
+ * - `"constraint_violation"`: one design vs. a fixed project rule
+ *   (`DesignConstraintType`, now a single value -- see its own doc
+ *   comment). Always blocks. The one bucket where a third party (an
+ *   admin) approves an override, not the developer who hit it -- it's
+ *   someone else's rule, not theirs to waive alone. (Was
+ *   `"constraint_flag"`.)
+ * - `"symbol_conflict"`: two designs' *actual edits* collide -- a real
+ *   edit lands on a symbol another open design's owner also edited, or
+ *   declared as their own scope, or whose signature it silently broke.
+ *   Sourced from real `Claim`s (Tree-sitter), not self-reported scope --
+ *   see `checks.ts`/`design-divergence.ts`. Always blocks (whichever
+ *   side(s) have an open design at the time). Self-approvable: no third
+ *   party's rule is being overridden, just a peer collision, so whoever
+ *   ends up blocked can justify and clear their own block.
+ * - `"llm_divergence"`: two designs' *stated intent* conflict --
+ *   duplication, contradictory assumptions, or tension in shared system
+ *   behavior, judged by the semantic comparator
+ *   (`design-semantic-check.ts`'s `checkSemanticConflict`, driven by
+ *   app.ts's `runSemanticComparatorPass`) even when file lists never
+ *   overlap. Never returned synchronously by `runDesignChecks`
+ *   (design-checks.ts's tiers 1/3 run against the request that triggered
+ *   them); only ever set via `DesignRegistry.flag()` from the async
+ *   comparator pass, after its response has already been sent. Self-
+ *   approvable, same reasoning as `"symbol_conflict"`. (Was `"conflict"`.)
+ * - `"has_open_designs"`: not actually a conflict between two designs at
+ *   all -- a pre-registration hygiene check on one developer (too much of
+ *   their own work open at once), running *before* any row exists for
+ *   this request. Only reachable from `POST /v1/designs/check`'s
+ *   structured (non-`rawPlanText`) path, i.e. `twing design register`,
+ *   never `ExitPlanMode` -- see `DesignCheckResult.openDesigns`'s doc
+ *   comment.
+ *
+ * `DesignSeverity`/`severity` is gone as of this change: with tier 4 and
+ * the three-way constraint type both collapsed, whether a verdict blocks
+ * is now a pure, static function of the verdict itself (`file_overlap`
+ * never does; the other three always do) -- a field that can no longer
+ * vary independently of its own verdict was dead weight. Every former
+ * `severity === "error"` check becomes a static per-verdict table instead.
+ */
+export type DesignVerdict = "clean" | "file_overlap" | "constraint_violation" | "symbol_conflict" | "llm_divergence" | "has_open_designs";
 
-/** 2026-08-19: an `overlap`/`constraint_flag` verdict is no longer
- * uniformly blocking -- `severity` says which of the two it is. `"warning"`
- * is display-only: the conflict is recorded (activity feed, design detail)
- * but the design stays `"open"` and no gate denies anything. `"error"` is
- * today's original behavior, unchanged: the design gets demoted to
- * `"flagged"` (design-store.ts's `flag()`), which is what the Edit/Write
- * gate's `/v1/designs/scope-match` and ExitPlanMode's registration-time
- * check both key off to deny. As of 2026-08-22, both `exactOverlap` (tier 1)
- * and `summarySimilarity` (tier 4) are `"warning"` -- only `constraintMatch`
- * (tier 3) stays `"error"` among the synchronous tiers. Absent/undefined on
- * a `"clean"` verdict, where severity is moot. `"conflict"` verdicts don't
- * carry a `DesignSeverity` at all -- they're set directly via `flag()` from
- * the async comparator pass, never through `DesignCheckResult`. */
-export type DesignSeverity = "warning" | "error";
-
-export type DesignOverlapKind = "creates" | "touches" | "constraint";
+export type DesignOverlapKind = "creates" | "touches" | "constraint" | "symbol";
 
 export interface DesignConflict {
   conflictingDesignId: string;
@@ -312,8 +350,6 @@ export interface DesignCheckResult {
    * only discover the next one on retry. See design-checks.ts's own doc
    * comment on `matchConstraintsForPaths` for the full reasoning. */
   constraints?: { id: string; statement: string; type: DesignConstraintType }[];
-  /** See DesignSeverity. Undefined for `"clean"`. */
-  severity?: DesignSeverity;
   /** Set only for `"has_open_designs"` (2026-08-25) -- the developer's other
    * currently-open designs, cross-project, that a plain `twing design
    * register` call found before creating a new row. Lets the CLI print
@@ -329,9 +365,10 @@ export interface PendingReview {
   justification: string;
   createdAt: number;
   decision?: "approve" | "reject";
-  /** Set only when this review was created against a `constraint_flag`
-   * verdict (undefined for an `overlap`-triggered justified_divergence).
-   * Recorded so an approval can be attributed to the *specific* constraints
+  /** Set only when this review was created against a `constraint_violation`
+   * verdict (undefined for a `symbol_conflict`/`llm_divergence`-triggered
+   * justified_divergence). Recorded so an approval can be attributed to the
+   * *specific* constraints
    * it settled -- see DesignStatement.justifiedConstraintIds. Plural
    * (2026-08-22, was a single `constraintId`) for the same reason
    * `DesignCheckResult.constraints` is now a list -- one justified
@@ -352,14 +389,24 @@ export interface PendingReview {
    * this. */
   overlapWaivers?: { conflictingDesignId: string; paths: string[] }[];
   /** Semantic comparator's counterpart to `overlapWaivers` above
-   * (2026-08-22) -- set only when this design currently has a `"conflict"`
-   * flag against it (recorded conflicts, not recomputed live at
-   * justify-time: unlike `overlapWaivers`'s cheap local recompute, a live
-   * recheck here would mean a second synchronous LLM call inside
+   * (2026-08-22) -- set only when this design currently has an
+   * `"llm_divergence"` flag against it (recorded conflicts, not recomputed
+   * live at justify-time: unlike `overlapWaivers`'s cheap local recompute, a
+   * live recheck here would mean a second synchronous LLM call inside
    * `/v1/designs/:id/resolve`). One entry per conflicting design, no paths
    * -- see DesignStatement.justifiedConflicts for how an approval consumes
    * this. */
   conflictWaivers?: { conflictingDesignId: string }[];
+  /** `"symbol_conflict"`'s counterpart to `overlapWaivers` above
+   * (2026-08-26) -- sourced the same way `conflictWaivers` is: read back
+   * from this design's open `category: "symbol_conflict"` alignment
+   * threads (`symbolIds`/`designId`), not recomputed live -- there's no
+   * cheap local recompute for "which real edits collided" the way
+   * `structuralOverlaps` provides for `overlapWaivers`. One entry per
+   * conflicting design, naming the specific symbols that collided -- see
+   * DesignStatement.justifiedSymbolConflicts for how an approval consumes
+   * this. */
+  symbolConflictWaivers?: { conflictingDesignId: string; symbolIds: string[] }[];
 }
 
 /**
@@ -397,12 +444,13 @@ export interface ReviewConstraintSummary {
  * merged here, with `kind` preserving which check produced it. */
 export interface ReviewConflictSummary {
   designId: string;
-  kind: "overlap" | "conflict";
+  kind: "overlap" | "conflict" | "symbol_conflict";
   /** Absent if the conflicting design has since been deleted. */
   summary?: string;
   developerId?: string;
-  /** Only ever set for `kind: "overlap"` -- the semantic comparator has no
-   * specific path to point at. */
+  /** Set for `kind: "overlap"` and `kind: "symbol_conflict"` -- the
+   * semantic comparator (`kind: "conflict"`) has no specific path to point
+   * at. */
   paths?: string[];
 }
 

--- a/packages/server/drizzle/0011_design-conflict-model-simplification.sql
+++ b/packages/server/drizzle/0011_design-conflict-model-simplification.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `alignment_threads` ADD `sub_kind` text;--> statement-breakpoint
+ALTER TABLE `designs` ADD `justified_symbol_conflicts` text DEFAULT '[]' NOT NULL;--> statement-breakpoint
+ALTER TABLE `pending_reviews` ADD `symbol_conflict_waivers` text DEFAULT '[]' NOT NULL;

--- a/packages/server/drizzle/meta/0011_snapshot.json
+++ b/packages/server/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,943 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7c0e8ba9-e325-4584-b6cd-f831fb64ca7c",
+  "prevId": "ff1c8c85-fd89-47a6-bd91-b68fe1274fdb",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_id": {
+          "name": "related_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_events_project_ts_idx": {
+          "name": "activity_events_project_ts_idx",
+          "columns": [
+            "project_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "activity_events_related_id_idx": {
+          "name": "activity_events_related_id_idx",
+          "columns": [
+            "related_id"
+          ],
+          "isUnique": false
+        },
+        "activity_events_kind_idx": {
+          "name": "activity_events_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alignment_threads": {
+      "name": "alignment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol_id": {
+          "name": "symbol_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "other_developer_id": {
+          "name": "other_developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_description": {
+          "name": "system_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sub_kind": {
+          "name": "sub_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol_ids": {
+          "name": "symbol_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "initiating_design_id": {
+          "name": "initiating_design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alignment_threads_project_id_idx": {
+          "name": "alignment_threads_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "constraints": {
+      "name": "constraints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "constraints_project_id_idx": {
+          "name": "constraints_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "constraints_project_statement_uidx": {
+          "name": "constraints_project_statement_uidx",
+          "columns": [
+            "project_id",
+            "statement"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "designs": {
+      "name": "designs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_label": {
+          "name": "agent_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creates": {
+          "name": "creates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "touches": {
+          "name": "touches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depends_on": {
+          "name": "depends_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_plan_excerpt": {
+          "name": "raw_plan_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttl_ms": {
+          "name": "ttl_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_version": {
+          "name": "scope_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "justified_constraint_ids": {
+          "name": "justified_constraint_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "justified_overlaps": {
+          "name": "justified_overlaps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "justified_conflicts": {
+          "name": "justified_conflicts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "justified_symbol_conflicts": {
+          "name": "justified_symbol_conflicts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "designs_project_id_idx": {
+          "name": "designs_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "designs_session_id_idx": {
+          "name": "designs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "designs_group_id_idx": {
+          "name": "designs_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "developers": {
+      "name": "developers",
+      "columns": {
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "developers_token_hash_unique": {
+          "name": "developers_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_project_id": {
+          "name": "scope_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by": {
+          "name": "consumed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_memberships": {
+      "name": "org_memberships",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_memberships_org_id_developer_id_pk": {
+          "columns": [
+            "org_id",
+            "developer_id"
+          ],
+          "name": "org_memberships_org_id_developer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_reviews": {
+      "name": "pending_reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "constraint_ids": {
+          "name": "constraint_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "overlap_waivers": {
+          "name": "overlap_waivers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "conflict_waivers": {
+          "name": "conflict_waivers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "symbol_conflict_waivers": {
+          "name": "symbol_conflict_waivers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "pending_reviews_project_id_idx": {
+          "name": "pending_reviews_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_memberships": {
+      "name": "project_memberships",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_memberships_project_id_developer_id_pk": {
+          "columns": [
+            "project_id",
+            "developer_id"
+          ],
+          "name": "project_memberships_project_id_developer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_records": {
+      "name": "project_records",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "founded_by": {
+          "name": "founded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roadmap_items": {
+      "name": "roadmap_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roadmap_items_project_id_idx": {
+          "name": "roadmap_items_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787645552154,
       "tag": "0010_design-group-linking",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1787730650542,
+      "tag": "0011_design-conflict-model-simplification",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/alignment-store.test.ts
+++ b/packages/server/src/alignment-store.test.ts
@@ -16,7 +16,8 @@ const baseInput = {
   otherDeveloperId: "bob",
   designId: "d1",
   systemDescription: "alice's edit falls inside bob's open design",
-  category: "symbol_claim" as const,
+  category: "symbol_conflict" as const,
+  subKind: "scope_intrusion" as const,
   summary: "1 overlapping path with \"bob's design\"",
   initiatingDesignId: "alice-design-1",
 };
@@ -25,7 +26,7 @@ test("AlignmentThreadStore: findOrCreate opens a new thread and seeds it with th
   const { store } = freshStore();
   const thread = store.findOrCreate(baseInput);
   assert.equal(thread.status, "open");
-  assert.equal(thread.category, "symbol_claim");
+  assert.equal(thread.category, "symbol_conflict");
   assert.equal(thread.summary, baseInput.summary);
   assert.deepEqual(thread.symbolIds, baseInput.symbolIds);
   assert.equal(thread.initiatingDesignId, "alice-design-1");
@@ -60,13 +61,13 @@ test("AlignmentThreadStore: a new overlapping symbol amends the existing open th
 
 test("AlignmentThreadStore: a semantic-conflict re-check always posts a follow-up message, even with no new symbols", () => {
   const { store } = freshStore();
-  const semanticInput = { ...baseInput, category: "tension" as const, symbolIds: [], systemDescription: "first tension finding" };
+  const semanticInput = { ...baseInput, category: "llm_divergence" as const, subKind: "tension" as const, symbolIds: [], systemDescription: "first tension finding" };
   const first = store.findOrCreate(semanticInput);
   const second = store.findOrCreate({ ...semanticInput, systemDescription: "re-checked after an amend, still tension" });
 
   assert.equal(first.id, second.id);
   const messages = store.messages(first.id);
-  assert.equal(messages.length, 2, "every semantic-conflict finding is fresh, unlike a repeated symbol_claim");
+  assert.equal(messages.length, 2, "every semantic-conflict finding is fresh, unlike a repeated symbol_conflict");
   assert.equal(messages[1].message, "re-checked after an amend, still tension");
 });
 
@@ -167,8 +168,8 @@ test("buildAlignmentSummary: templates a concise label per category, capping a l
   assert.equal(buildAlignmentSummary("duplication", "Add retry backoff", 0), 'Duplicate work with "Add retry backoff"');
   assert.equal(buildAlignmentSummary("contradictory_assumptions", "Add retry backoff", 0), 'Contradicts "Add retry backoff"');
   assert.equal(buildAlignmentSummary("tension", "Add retry backoff", 0), 'Tension with "Add retry backoff"');
-  assert.equal(buildAlignmentSummary("symbol_claim", "Add retry backoff", 1), '1 overlapping path with "Add retry backoff"');
-  assert.equal(buildAlignmentSummary("symbol_claim", "Add retry backoff", 3), '3 overlapping paths with "Add retry backoff"');
+  assert.equal(buildAlignmentSummary("real_edit_collision", "Add retry backoff", 1), '1 overlapping symbol with "Add retry backoff"');
+  assert.equal(buildAlignmentSummary("real_edit_collision", "Add retry backoff", 3), '3 overlapping symbols with "Add retry backoff"');
   assert.equal(buildAlignmentSummary("duplication", "(no summary)", 0), 'Duplicate work with "(no summary)"');
 
   const long = "x".repeat(120);

--- a/packages/server/src/alignment-store.ts
+++ b/packages/server/src/alignment-store.ts
@@ -1,6 +1,8 @@
 /**
  * Alignment threads (statefulness redesign, 2026-08) -- the "conversation
- * layer" for a `design_divergence` finding (`design-divergence.ts`):
+ * layer" for a `symbol_conflict` or `llm_divergence` finding (see
+ * `checks.ts`/`design-divergence.ts` for the three finding kinds that feed
+ * `symbol_conflict`, and `design-semantic-check.ts` for `llm_divergence`):
  * async, mailbox-style, never live. A thread is a small current-state table
  * (id, parties, status), exactly like `designs`; every message in it,
  * including the auto-generated seed note, is an `activity_events` row
@@ -8,9 +10,14 @@
  * table -- same "current-state table + log entries" pattern as everything
  * else in this schema, and it keeps the history genuinely append-only.
  *
- * Deliberately advisory: nothing here ever blocks a tool call. Closing a
- * thread is unilateral -- either party can close it without the other
- * agreeing, since this is for voluntary reconciliation, not enforcement.
+ * The thread itself stays purely advisory -- closing it (below) is
+ * unilateral and never blocks or unblocks a tool call by itself. As of the
+ * 2026-08-26 terminology simplification, both `symbol_conflict` and
+ * `llm_divergence` *do* independently flag/block via `DesignRegistry.flag()`
+ * (see app.ts) -- the thread is the conversation about *why*, cleared via
+ * `twing design resolve --justify` (self-approvable for both buckets), not
+ * by closing the thread. See `DesignVerdict`'s doc comment in
+ * core/types.ts for the full model.
  */
 
 import * as crypto from "node:crypto";
@@ -19,14 +26,47 @@ import type { Db } from "./db/client.js";
 import { alignmentThreads as threadsTable } from "./db/schema.js";
 import { DrizzleActivityLog } from "./activity-log.js";
 
-/** What kind of divergence a thread represents -- 2026-08-23. The three
- * semantic values mirror `SemanticConflictKind` (`design-semantic-check.ts`)
- * exactly, since that's their only producer; `symbol_claim` is the
- * claims-path (`design-divergence.ts`) equivalent -- a real edit landing in
- * someone else's declared scope, as opposed to two designs' *content*
- * conflicting. Undefined on pre-2026-08-23 rows (never backfilled -- see
- * this file's header comment on why old threads stay as-is). */
-export type AlignmentCategory = "duplication" | "contradictory_assumptions" | "tension" | "symbol_claim";
+/** Which of the two self-approvable design-conflict buckets a thread
+ * represents (2026-08-26 terminology simplification -- see
+ * `DesignVerdict`'s doc comment in core/types.ts for the full four-bucket
+ * model). Collapsed from a four-way
+ * `"duplication" | "contradictory_assumptions" | "tension" | "symbol_claim"`
+ * union: those four were a bucket name and its sub-reason tangled into one
+ * field. The bucket name is now just these two values; the old four values
+ * survive as `subKind` below, detail text under the bucket rather than a
+ * competing top-level name. A pre-2026-08-26 row keeps its old value here
+ * unconverted -- never backfilled, same convention this table already
+ * followed for its pre-2026-08-23 rows; a reader that needs to treat old
+ * rows uniformly with new ones should go through `legacyCategoryBucket`
+ * below rather than compare `category` directly. */
+export type AlignmentCategory = "symbol_conflict" | "llm_divergence";
+
+/** Detail label shown under the bucket name -- `duplication` /
+ * `contradictory_assumptions` / `tension` for `llm_divergence` (mirrors
+ * `SemanticConflictKind`, `design-semantic-check.ts`, its only producer),
+ * or `real_edit_collision` / `scope_intrusion` / `contract_break` for
+ * `symbol_conflict` (mirrors the three finding kinds that now feed it --
+ * `textual_overlap` / `design_divergence` / `contract_divergence`, see
+ * `checks.ts`/`design-divergence.ts`). Undefined on any row that predates
+ * this column. */
+export type AlignmentSubKind = "duplication" | "contradictory_assumptions" | "tension" | "real_edit_collision" | "scope_intrusion" | "contract_break";
+
+/** Legacy pre-2026-08-26 `category` strings, mapped to which of the two
+ * current buckets they represent -- for any reader that needs to treat old
+ * rows uniformly with new ones (list-view filtering, etc.) without a
+ * backfill. */
+export function legacyCategoryBucket(raw: string): AlignmentCategory | undefined {
+  switch (raw) {
+    case "duplication":
+    case "contradictory_assumptions":
+    case "tension":
+      return "llm_divergence";
+    case "symbol_claim":
+      return "symbol_conflict";
+    default:
+      return undefined;
+  }
+}
 
 export interface AlignmentThread {
   id: string;
@@ -44,11 +84,14 @@ export interface AlignmentThread {
   closedAt?: number;
   closedBy?: string;
   category?: AlignmentCategory;
+  /** Detail label under the bucket name -- see `AlignmentSubKind`'s own
+   * doc comment. Undefined on any row that predates this column. */
+  subKind?: AlignmentSubKind;
   /** Short, list-view label -- distinct from `systemDescription`, which
    * stays the full-text description. Undefined on pre-2026-08-23 rows. */
   summary?: string;
   /** Every distinct overlapping path/symbol accumulated across amendments.
-   * Only meaningful for `category: "symbol_claim"`. Falls back to
+   * Only meaningful for `category: "symbol_conflict"`. Falls back to
    * `[symbolId]` for a pre-2026-08-23 row that never had this column. */
   symbolIds: string[];
   /** The initiating developer's own open design, when one resolves --
@@ -81,6 +124,7 @@ export interface FindOrCreateInput {
   designId?: string;
   systemDescription: string;
   category: AlignmentCategory;
+  subKind: AlignmentSubKind;
   summary: string;
   initiatingDesignId?: string;
   ts?: number;
@@ -99,6 +143,7 @@ interface ThreadRow {
   closedAt: number | null;
   closedBy: string | null;
   category: string | null;
+  subKind: string | null;
   summary: string | null;
   symbolIds: string;
   initiatingDesignId: string | null;
@@ -120,6 +165,7 @@ function fromRow(row: ThreadRow): AlignmentThread {
     closedAt: row.closedAt ?? undefined,
     closedBy: row.closedBy ?? undefined,
     category: (row.category as AlignmentCategory | null) ?? undefined,
+    subKind: (row.subKind as AlignmentSubKind | null) ?? undefined,
     summary: row.summary ?? undefined,
     symbolIds: parsedSymbolIds.length > 0 ? parsedSymbolIds : row.symbolId ? [row.symbolId] : [],
     initiatingDesignId: row.initiatingDesignId ?? undefined,
@@ -127,21 +173,27 @@ function fromRow(row: ThreadRow): AlignmentThread {
   };
 }
 
-/** Short list-view label per category -- deterministic, no LLM call (the
+/** Short list-view label per sub-kind -- deterministic, no LLM call (the
  * semantic comparator already spent one producing `systemDescription`'s
  * full reason; this just needs a title). Capped defensively so a long
- * design summary can't blow up the list view. */
-export function buildAlignmentSummary(category: AlignmentCategory, otherDesignSummary: string, symbolCount: number): string {
+ * design summary can't blow up the list view. Keyed by `subKind`, not the
+ * top-level `category` -- the label needs the specific reason
+ * ("duplicate work" vs. "contradicts"), which only the sub-kind carries. */
+export function buildAlignmentSummary(subKind: AlignmentSubKind, otherDesignSummary: string, symbolCount: number): string {
   const other = otherDesignSummary.length > 80 ? `${otherDesignSummary.slice(0, 79)}…` : otherDesignSummary || "(no summary)";
-  switch (category) {
+  switch (subKind) {
     case "duplication":
       return `Duplicate work with "${other}"`;
     case "contradictory_assumptions":
       return `Contradicts "${other}"`;
     case "tension":
       return `Tension with "${other}"`;
-    case "symbol_claim":
-      return `${symbolCount} overlapping path${symbolCount === 1 ? "" : "s"} with "${other}"`;
+    case "real_edit_collision":
+      return `${symbolCount} overlapping symbol${symbolCount === 1 ? "" : "s"} with "${other}"`;
+    case "scope_intrusion":
+      return `Edit landed inside "${other}"'s declared scope`;
+    case "contract_break":
+      return `Signature change breaks a live caller in "${other}"`;
   }
 }
 
@@ -202,6 +254,7 @@ export class AlignmentThreadStore {
       systemDescription: input.systemDescription,
       openedAt: ts,
       category: input.category,
+      subKind: input.subKind,
       summary: input.summary,
       symbolIds: input.symbolIds,
       initiatingDesignId: input.initiatingDesignId,
@@ -222,6 +275,7 @@ export class AlignmentThreadStore {
         closedAt: null,
         closedBy: null,
         category: thread.category ?? null,
+        subKind: thread.subKind ?? null,
         summary: thread.summary ?? null,
         symbolIds: JSON.stringify(thread.symbolIds),
         initiatingDesignId: thread.initiatingDesignId ?? null,
@@ -253,10 +307,10 @@ export class AlignmentThreadStore {
     const ts = input.ts ?? Date.now();
     const mergedSymbolIds = Array.from(new Set([...existing.symbolIds, ...input.symbolIds]));
     const newSymbolIds = input.symbolIds.filter((s) => !existing.symbolIds.includes(s));
-    // A symbol_claim thread only has something new to say when a symbol it
-    // hasn't seen before shows up; a semantic-conflict re-check is always
+    // A symbol_conflict thread only has something new to say when a symbol
+    // it hasn't seen before shows up; an llm_divergence re-check is always
     // itself a fresh LLM finding, so it's always worth a follow-up message.
-    const hasNewSignal = input.category !== "symbol_claim" || newSymbolIds.length > 0;
+    const hasNewSignal = input.category !== "symbol_conflict" || newSymbolIds.length > 0;
     const resolvedInitiatingDesignId = existing.initiatingDesignId ?? input.initiatingDesignId;
 
     this.db

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -361,7 +361,7 @@ test("POST /v1/reviews/:id/decide: requires the project's admin role, not mere a
   });
   assert.equal(check2.status, 200);
   const check2Body = (await check2.json()) as { verdict: string; designId: string };
-  assert.equal(check2Body.verdict, "overlap");
+  assert.equal(check2Body.verdict, "file_overlap");
 
   const resolveRes = await app.request(`/v1/designs/${check2Body.designId}/resolve`, {
     method: "POST",
@@ -407,6 +407,21 @@ async function makePendingReview(app: ReturnType<typeof createApp>, token: strin
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(token) },
     body: JSON.stringify({ projectId, sessionId: "s1", summary: "first", creates: ["a.ts"], touches: [], dependsOn: [] }),
+  });
+
+  // 2026-08-26 self-approve: a review with only a structural-overlap waiver
+  // and no constraint hit auto-decides immediately on resolve (see
+  // DesignVerdict's doc comment, core/types.ts -- constraint_violation is
+  // the only bucket that still needs an admin). This helper is named/used
+  // for the admin-review-queue surface (GET /v1/reviews, enrichment), which
+  // needs the review to actually stay pending -- so seed a constraint that
+  // also matches "a.ts", forcing the resolve below into the still-admin-
+  // gated path, while still keeping the structural overlap so the enriched
+  // review's conflicts array carries a real `kind: "overlap"` entry too.
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(token) },
+    body: JSON.stringify({ projectId, constraints: [{ statement: "a.ts needs sign-off", scope: ["a.ts"] }] }),
   });
 
   // A genuinely different developer registers the "overlapping" second
@@ -724,11 +739,12 @@ test("GET /v1/activity: design_checked/design_flagged carry the full why (confli
   const { app, dataDir, designs } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
 
-  // Tier 4 (summary similarity) -- non-blocking as of 2026-08-22 (see
-  // design-checks.ts's header comment), same as tier 1. Distinct,
-  // non-overlapping touches so tier 1 doesn't fire first; near-identical
-  // summaries so tier 4's Jaccard fallback does, populating `conflicts` on
-  // design_checked even though it no longer flags anything by itself.
+  // Tier 1 (exact touches overlap) -- always advisory (file_overlap never
+  // blocks, see DesignVerdict's doc comment, core/types.ts). Tier 4
+  // (summary similarity) was removed entirely 2026-08-26 -- llm_divergence
+  // (the semantic comparator) is its real replacement -- so tier 1 is now
+  // the only source of an always-advisory, conflicts-populating verdict to
+  // exercise here.
   const firstRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
@@ -745,7 +761,7 @@ test("GET /v1/activity: design_checked/design_flagged carry the full why (confli
   assert.equal(firstBody.verdict, "clean");
 
   // A genuinely different developer registers the "second" design -- same-
-  // developer pairs no longer produce an overlap verdict at all
+  // developer pairs no longer produce a file_overlap verdict at all
   // (2026-08-22). Must come after proj-1 is founded above.
   const otherPat = await addProjectMember(app, admin.token, "proj-1");
 
@@ -757,20 +773,20 @@ test("GET /v1/activity: design_checked/design_flagged carry the full why (confli
       sessionId: "s2",
       summary: "adds a shared caching layer for the billing service",
       creates: [],
-      touches: ["billing.ts"],
+      touches: ["payments.ts"], // exact overlap with the first design -- tier 1
       dependsOn: [],
     }),
   });
-  const secondBody = (await secondRes.json()) as { verdict: string; designId: string; severity?: string };
-  assert.equal(secondBody.verdict, "overlap");
-  assert.equal(secondBody.severity, "warning", "sanity: tier 4 is warning-severity (2026-08-22) -- design_checked still logs conflicts on its own; design_flagged now only comes from the async semantic-conflict path (runSemanticComparatorPass)");
+  const secondBody = (await secondRes.json()) as { verdict: string; designId: string };
+  assert.equal(secondBody.verdict, "file_overlap", "tier 1 -- design_checked still logs conflicts on its own; design_flagged now only comes from the async semantic-conflict path (runSemanticComparatorPass)");
 
   // Simulate what runSemanticComparatorPass (app.ts) does on a real
-  // conflict hit -- flags the design directly, same DesignConflict detail
-  // shape tiers 1/4 already use. Exercised this way rather than through the
-  // real LLM call: this test is about design_flagged's activity-log detail
-  // carrying through, not about the LLM's own judgment.
-  designs.flag(secondBody.designId, "conflict", {
+  // llm_divergence hit -- flags the design directly, same DesignConflict
+  // detail shape tier 1 already uses. Exercised this way rather than
+  // through the real LLM call: this test is about design_flagged's
+  // activity-log detail carrying through, not about the LLM's own
+  // judgment.
+  designs.flag(secondBody.designId, "llm_divergence", {
     conflicts: [
       {
         conflictingDesignId: firstBody.designId,
@@ -788,12 +804,12 @@ test("GET /v1/activity: design_checked/design_flagged carry the full why (confli
 
   const checked = activityBody.items.find((e) => e.kind === "design_checked");
   assert.ok(checked, "?relatedId= must scope to just this design's own events");
-  assert.equal(checked!.payload?.verdict, "overlap");
+  assert.equal(checked!.payload?.verdict, "file_overlap");
   assert.equal(checked!.payload?.summary, "adds a shared caching layer for the billing service");
   assert.equal(checked!.payload?.conflicts?.[0]?.conflictingSummary, "adds a shared caching layer for the payments service");
 
   const flagged = activityBody.items.find((e) => e.kind === "design_flagged");
-  assert.ok(flagged, "a non-clean, error-severity verdict must also log design_flagged");
+  assert.ok(flagged, "the simulated llm_divergence flag must also log design_flagged");
   assert.equal(flagged!.payload?.summary, "adds a shared caching layer for the billing service");
   assert.equal(flagged!.payload?.conflicts?.[0]?.conflictingSummary, "adds a shared caching layer for the payments service");
 
@@ -819,7 +835,7 @@ test("GET /v1/constraints: lists every constraint seeded for a project", async (
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({
       projectId: "proj-1",
-      constraints: [{ statement: "don't invent a second wire format", scope: ["packages/core/src/framing.ts"], type: "canonical_abstraction" }],
+      constraints: [{ statement: "don't invent a second wire format", scope: ["packages/core/src/framing.ts"], type: "constraint" }],
     }),
   });
 
@@ -828,7 +844,7 @@ test("GET /v1/constraints: lists every constraint seeded for a project", async (
   const body = (await res.json()) as { items: { statement: string; type: string }[] };
   assert.equal(body.items.length, 1);
   assert.equal(body.items[0].statement, "don't invent a second wire format");
-  assert.equal(body.items[0].type, "canonical_abstraction");
+  assert.equal(body.items[0].type, "constraint");
 });
 
 test("GET /v1/constraints: empty for a project with nothing seeded, not an error", async () => {
@@ -930,7 +946,7 @@ test("DELETE /v1/constraints/:id: an admin removes it unilaterally and immediate
   const { app, dataDir, constraints } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
   await foundProject(app, admin.token);
-  const constraint = constraints.add("proj-1", "use pkg/retry", ["src/**"], "canonical_abstraction", "seeded");
+  const constraint = constraints.add("proj-1", "use pkg/retry", ["src/**"], "constraint", "seeded");
 
   const res = await app.request(`/v1/constraints/${constraint.id}`, { method: "DELETE", headers: bearer(admin.token) });
   assert.equal(res.status, 200);
@@ -942,7 +958,7 @@ test("DELETE /v1/constraints/:id: a plain member is denied -- same admin-only ba
   const { app, dataDir, constraints } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
   await foundProject(app, admin.token);
-  const constraint = constraints.add("proj-1", "use pkg/retry", ["src/**"], "canonical_abstraction", "seeded");
+  const constraint = constraints.add("proj-1", "use pkg/retry", ["src/**"], "constraint", "seeded");
 
   const projInviteRes = await app.request("/v1/projects/proj-1/invites", {
     method: "POST",
@@ -973,7 +989,7 @@ test("DELETE /v1/constraints/:id: authorization runs against the constraint's ow
   const { app, dataDir, constraints } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
   await foundProject(app, admin.token);
-  const constraint = constraints.add("proj-1", "use pkg/retry", ["src/**"], "canonical_abstraction", "seeded");
+  const constraint = constraints.add("proj-1", "use pkg/retry", ["src/**"], "constraint", "seeded");
 
   // dave is a real, authenticated developer -- just not a member of proj-1
   // at all (an org invite, not a project one -- see makeUnrelatedDeveloper's
@@ -1083,11 +1099,12 @@ test("POST /v1/claims: a divergence claim on a *different* symbol against the sa
   assert.equal(secondThreadId, firstThreadId, "same developer pair + target design -- must amend, not fork");
 
   const listRes = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(bobToken) });
-  const listBody = (await listRes.json()) as { items: { id: string; symbolIds: string[]; category: string; summary: string }[] };
+  const listBody = (await listRes.json()) as { items: { id: string; symbolIds: string[]; category: string; subKind: string; summary: string }[] };
   assert.equal(listBody.items.length, 1, "one thread, not two");
   assert.deepEqual(listBody.items[0].symbolIds.sort(), ["src/x.ts::f", "src/x.ts::g"]);
-  assert.equal(listBody.items[0].category, "symbol_claim");
-  assert.match(listBody.items[0].summary, /overlapping path/);
+  assert.equal(listBody.items[0].category, "symbol_conflict");
+  assert.equal(listBody.items[0].subKind, "scope_intrusion", "a design_divergence finding -- an edit landing inside another's declared scope");
+  assert.match(listBody.items[0].summary, /declared scope/);
 });
 
 test("POST /v1/claims: a divergence finding links the claiming developer's own open design as initiatingDesignId, when they have one", async () => {
@@ -1328,13 +1345,14 @@ test("POST /v1/designs/check: the async semantic-conflict comparator opens an al
 
   const threadsRes = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(admin.token) });
   const threadsBody = (await threadsRes.json()) as {
-    items: { developerId: string; otherDeveloperId: string; systemDescription: string; category: string; summary: string; initiatingDesignId?: string }[];
+    items: { developerId: string; otherDeveloperId: string; systemDescription: string; category: string; subKind: string; summary: string; initiatingDesignId?: string }[];
   };
   assert.equal(threadsBody.items.length, 1);
   assert.equal(threadsBody.items[0].developerId, "bob@example.com");
   assert.equal(threadsBody.items[0].otherDeveloperId, "alice@example.com");
   assert.equal(threadsBody.items[0].systemDescription, "they fight over the same guarantee");
-  assert.equal(threadsBody.items[0].category, "tension", "matches the comparator's own SemanticConflictKind");
+  assert.equal(threadsBody.items[0].category, "llm_divergence", "the two self-approvable buckets' shared top-level name");
+  assert.equal(threadsBody.items[0].subKind, "tension", "matches the comparator's own SemanticConflictKind");
   assert.match(threadsBody.items[0].summary, /Tension with/);
   assert.equal(threadsBody.items[0].initiatingDesignId, bobDesignId, "the candidate design (bob's) is always resolvable on this path");
 
@@ -1381,16 +1399,17 @@ test("POST /v1/designs/check: the async semantic-conflict comparator produces no
 
 // --- §17 scope enforcement (2026-08): flag / scope-match / amend ---
 
-test("designs.flag(..., 'conflict', ...) persists as status 'flagged', not 'open' (§17 scope enforcement, async semantic-conflict path)", async () => {
+test("designs.flag(..., 'llm_divergence', ...) persists as status 'flagged', not 'open' (§17 scope enforcement, async semantic-conflict path)", async () => {
   const { app, dataDir, designs } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
 
-  // Since 2026-08-22 there's no longer a *synchronous* error-severity
-  // "overlap" verdict at all (tiers 1 and 4 are both "warning" now -- see
-  // the dedicated warning-severity test below). The design-vs-design
-  // conflict path that actually flags is the async semantic comparator
+  // Since 2026-08-26 the only synchronous verdicts /v1/designs/check can
+  // return are "clean", "file_overlap" (always advisory, tier 1), and
+  // "constraint_violation" (always blocks, tier 3) -- see DesignVerdict's
+  // doc comment, core/types.ts. The design-vs-design conflict path that
+  // actually flags with "llm_divergence" is the async semantic comparator
   // (runSemanticComparatorPass, app.ts), which calls designs.flag(id,
-  // "conflict", ...) directly once its LLM check returns -- exercised
+  // "llm_divergence", ...) directly once its LLM check returns -- exercised
   // here the same way, since this test is about status persistence, not
   // the LLM's own judgment (see design-eval.test.ts for that).
   const registerRes = await app.request("/v1/designs/check", {
@@ -1400,7 +1419,7 @@ test("designs.flag(..., 'conflict', ...) persists as status 'flagged', not 'open
   });
   const { designId } = (await registerRes.json()) as { designId: string };
 
-  designs.flag(designId, "conflict", {
+  designs.flag(designId, "llm_divergence", {
     conflicts: [
       {
         conflictingDesignId: "other-design-id",
@@ -1415,13 +1434,14 @@ test("designs.flag(..., 'conflict', ...) persists as status 'flagged', not 'open
   const listRes = await app.request(`/v1/designs?projectId=proj-1&sessionId=s2`, { headers: bearer(admin.token) });
   const listBody = (await listRes.json()) as { items: { id: string; status: string }[] };
   const registered = listBody.items.find((d) => d.id === designId);
-  assert.equal(registered?.status, "flagged", "a design flagged with a 'conflict' verdict must not read back as 'open'");
+  assert.equal(registered?.status, "flagged", "a design flagged with an 'llm_divergence' verdict must not read back as 'open'");
 });
 
-// 2026-08-19 severity split: tier 1's exactOverlap is display-only now --
-// this is the new counterpart to the test above, pinning the opposite
-// behavior for the same status/response-shape surface.
-test("POST /v1/designs/check: a warning-severity (tier 1 exact) overlap stays status 'open', not 'flagged'", async () => {
+// 2026-08-26: blocking is now a static function of verdict alone --
+// file_overlap (tier 1's exactOverlap) always stays advisory. This is the
+// counterpart to the test above, pinning that behavior for the same
+// status/response-shape surface.
+test("POST /v1/designs/check: a file_overlap (tier 1 exact) verdict stays status 'open', not 'flagged'", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
 
@@ -1430,30 +1450,28 @@ test("POST /v1/designs/check: a warning-severity (tier 1 exact) overlap stays st
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first, unrelated topic entirely", creates: ["a.ts"], touches: [], dependsOn: [] }),
   });
-  const otherPat = await addProjectMember(app, admin.token, "proj-1"); // same-developer pairs no longer produce an overlap verdict at all (2026-08-22); must come after proj-1 is founded above
+  const otherPat = await addProjectMember(app, admin.token, "proj-1"); // same-developer pairs no longer produce a file_overlap verdict at all (2026-08-22); must come after proj-1 is founded above
   const overlapRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(otherPat) },
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "second, also unrelated topic", creates: ["a.ts"], touches: [], dependsOn: [] }),
   });
-  const overlapBody = (await overlapRes.json()) as { verdict: string; designId: string; severity?: string };
-  assert.equal(overlapBody.verdict, "overlap");
-  assert.equal(overlapBody.severity, "warning");
+  const overlapBody = (await overlapRes.json()) as { verdict: string; designId: string };
+  assert.equal(overlapBody.verdict, "file_overlap");
 
   const listRes = await app.request(`/v1/designs?projectId=proj-1&sessionId=s2`, { headers: bearer(admin.token) });
   const listBody = (await listRes.json()) as { items: { id: string; status: string }[] };
   const registered = listBody.items.find((d) => d.id === overlapBody.designId);
-  assert.equal(registered?.status, "open", "a warning-severity overlap must not demote the design out of 'open'");
+  assert.equal(registered?.status, "open", "a file_overlap verdict must not demote the design out of 'open'");
 
   // Still visible for display -- the whole point of keeping it a flag at
   // all rather than silently dropping it.
   const activityRes = await app.request(`/v1/activity?projectId=proj-1&relatedId=${overlapBody.designId}`, { headers: bearer(admin.token) });
-  const activityBody = (await activityRes.json()) as { items: { kind: string; payload?: { verdict?: string; severity?: string } }[] };
+  const activityBody = (await activityRes.json()) as { items: { kind: string; payload?: { verdict?: string } }[] };
   const checked = activityBody.items.find((e) => e.kind === "design_checked");
   assert.ok(checked, "the check itself is still logged for the dashboard's activity feed");
-  assert.equal(checked!.payload?.verdict, "overlap");
-  assert.equal(checked!.payload?.severity, "warning");
-  assert.ok(!activityBody.items.some((e) => e.kind === "design_flagged"), "a warning-severity verdict must not also log design_flagged");
+  assert.equal(checked!.payload?.verdict, "file_overlap");
+  assert.ok(!activityBody.items.some((e) => e.kind === "design_flagged"), "a file_overlap verdict must not also log design_flagged");
 });
 
 test("GET /v1/designs: newest-first, optionally filtered by status/sessionId", async () => {
@@ -1530,7 +1548,7 @@ test("POST /v1/designs/check: a caller-supplied groupId links a registration in 
   assert.equal(second.groupId, first.groupId);
 
   // A different developer in proj-b registers a genuinely conflicting
-  // design against `second`'s own scope, to exercise the "overlap" verdict
+  // design against `second`'s own scope, to exercise the "file_overlap" verdict
   // response branch specifically -- confirms groupId is echoed there too,
   // not just on the "clean" branch (a separate `c.json()` call in the
   // route that could otherwise be missed).
@@ -1541,7 +1559,7 @@ test("POST /v1/designs/check: a caller-supplied groupId links a registration in 
     body: JSON.stringify({ projectId: "proj-b", sessionId: "s3", summary: "conflicting", creates: ["b.ts"], touches: [], dependsOn: [] }),
   });
   const conflict = (await conflictRes.json()) as { verdict: string; designId: string; groupId?: string };
-  assert.equal(conflict.verdict, "overlap");
+  assert.equal(conflict.verdict, "file_overlap");
   assert.equal(conflict.groupId, conflict.designId, "the conflicting design got its own default group, unrelated to the linked pair's");
 });
 
@@ -1655,7 +1673,7 @@ test("POST /v1/designs/check: two linked designs in different projects with over
     // Deliberately the SAME path as `first`'s touches, in a DIFFERENT
     // project, linked via groupId -- if openDesigns or any overlap check
     // ever compared across projects because of the shared groupId, this
-    // would come back "overlap" instead of "clean".
+    // would come back "file_overlap" instead of "clean".
     body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "repo-B half", creates: [], touches: ["shared/path.ts"], dependsOn: [], groupId: first.groupId }),
   });
   const second = (await secondRes.json()) as { designId: string; groupId?: string; verdict: string };
@@ -1683,13 +1701,13 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
   const outOfScope = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=z.ts`, { headers: bearer(admin.token) });
   assert.deepEqual(await outOfScope.json(), { state: "out_of_scope", designId, openDesigns: [{ id: designId, summary: "" }] });
 
-  // A constraint match (tier 3, error severity), not tier 1 exact overlap --
-  // since the 2026-08-19 severity split tier 1 is "warning" severity and no
-  // longer reaches "flagged" (see the dedicated warning-severity test).
+  // A constraint match (tier 3, verdict constraint_violation), not tier 1
+  // exact overlap -- file_overlap always stays advisory and never reaches
+  // "flagged" (see the dedicated file_overlap test above).
   await app.request("/v1/constraints/seed", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["protected.ts"], type: "canonical_abstraction" }] }),
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["protected.ts"], type: "constraint" }] }),
   });
   const flaggedRegisterRes = await app.request("/v1/designs/check", {
     method: "POST",
@@ -1697,10 +1715,12 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["protected.ts"], dependsOn: [], force: true }),
   });
   const { designId: flaggedId, verdict: flaggedVerdict } = (await flaggedRegisterRes.json()) as { designId: string; verdict: string };
-  assert.equal(flaggedVerdict, "constraint_flag");
+  assert.equal(flaggedVerdict, "constraint_violation");
 
   const flagged = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s2&path=protected.ts`, { headers: bearer(admin.token) });
-  assert.deepEqual(await flagged.json(), { state: "flagged", designId: flaggedId, pendingReview: false });
+  // requiresAdmin: true because this design was flagged by a constraint
+  // violation -- the one bucket that still needs an admin to clear.
+  assert.deepEqual(await flagged.json(), { state: "flagged", designId: flaggedId, pendingReview: false, requiresAdmin: true });
 
   // §17 review-flow fix (2026-08-16): pendingReview flips true once resolve
   // is called, without a decide -- the deny message needs to be able to
@@ -1713,7 +1733,7 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
   assert.equal(resolveRes.status, 200);
 
   const flaggedAfterResolve = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s2&path=protected.ts`, { headers: bearer(admin.token) });
-  assert.deepEqual(await flaggedAfterResolve.json(), { state: "flagged", designId: flaggedId, pendingReview: true });
+  assert.deepEqual(await flaggedAfterResolve.json(), { state: "flagged", designId: flaggedId, pendingReview: true, requiresAdmin: true });
 });
 
 // Found live (2026-08-25): with more than one open design in the same
@@ -1786,7 +1806,7 @@ test("POST /v1/designs/check: a flagged design stays visible to a *third* design
   await app.request("/v1/constraints/seed", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["constrained.ts"], type: "canonical_abstraction" }] }),
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["constrained.ts"], type: "constraint" }] }),
   });
   // "third" is registered by a different developer than "second" -- same-
   // developer pairs no longer produce a tier-1 overlap verdict at all
@@ -1803,9 +1823,8 @@ test("POST /v1/designs/check: a flagged design stays visible to a *third* design
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "second", creates: [], touches: ["shared.ts", "constrained.ts"], dependsOn: [], force: true }),
   });
-  const secondBody = (await secondRes.json()) as { verdict: string; designId: string; severity?: string };
-  assert.equal(secondBody.verdict, "constraint_flag");
-  assert.equal(secondBody.severity, "error", "sanity: 'second' must actually be flagged, or this test isn't exercising what it claims to");
+  const secondBody = (await secondRes.json()) as { verdict: string; designId: string };
+  assert.equal(secondBody.verdict, "constraint_violation");
 
   const thirdRes = await app.request("/v1/designs/check", {
     method: "POST",
@@ -1813,7 +1832,7 @@ test("POST /v1/designs/check: a flagged design stays visible to a *third* design
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s3", summary: "third, also overlapping", creates: [], touches: ["shared.ts"], dependsOn: [] }),
   });
   const thirdBody = (await thirdRes.json()) as { verdict: string; conflicts: { conflictingDesignId: string }[] };
-  assert.equal(thirdBody.verdict, "overlap", "a flagged design must not become invisible to new registrations' structural overlap checks");
+  assert.equal(thirdBody.verdict, "file_overlap", "a flagged design must not become invisible to new registrations' structural overlap checks");
   assert.ok(
     thirdBody.conflicts.some((c) => c.conflictingDesignId === secondBody.designId),
     "the flagged (second) design specifically should show up as a conflict, not just the still-open first one",
@@ -1989,7 +2008,7 @@ test("POST /v1/designs/:id/amend: a conflicting amendment persists the merged sc
   await app.request("/v1/constraints/seed", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["constrained.ts"], type: "canonical_abstraction" }] }),
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["constrained.ts"], type: "constraint" }] }),
   });
   const registerRes = await app.request("/v1/designs/check", {
     method: "POST",
@@ -2003,9 +2022,8 @@ test("POST /v1/designs/:id/amend: a conflicting amendment persists the merged sc
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ addTouches: ["constrained.ts"] }),
   });
-  const amendBody = (await amendRes.json()) as { verdict: string; designId: string; severity?: string };
-  assert.equal(amendBody.verdict, "constraint_flag");
-  assert.equal(amendBody.severity, "error", "sanity: must be error-severity, or this test isn't exercising the flagging path");
+  const amendBody = (await amendRes.json()) as { verdict: string; designId: string };
+  assert.equal(amendBody.verdict, "constraint_violation");
 
   // Demoted out of "open" (not usable for the gate) but addressable, and --
   // the actual fix -- its scope now reflects exactly what was proposed, not
@@ -2021,7 +2039,7 @@ test("POST /v1/designs/:id/amend: a conflicting amendment persists the merged sc
 // 2026-08-19 severity split: same shape as above, but a warning-severity
 // (tier 1) amendment must persist and stay "open" -- no flag, no review
 // needed, matching a fresh registration's warning-severity behavior.
-test("POST /v1/designs/:id/amend: a warning-severity (tier 1 exact) amendment persists and stays 'open'", async () => {
+test("POST /v1/designs/:id/amend: a file_overlap (tier 1 exact) amendment persists and stays 'open'", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
   const otherPat = await addProjectMember(app, admin.token, "proj-1"); // same-developer pairs no longer produce an overlap verdict at all (2026-08-22)
@@ -2043,14 +2061,13 @@ test("POST /v1/designs/:id/amend: a warning-severity (tier 1 exact) amendment pe
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ addTouches: ["shared.ts"] }),
   });
-  const amendBody = (await amendRes.json()) as { verdict: string; designId: string; severity?: string };
-  assert.equal(amendBody.verdict, "overlap");
-  assert.equal(amendBody.severity, "warning");
+  const amendBody = (await amendRes.json()) as { verdict: string; designId: string };
+  assert.equal(amendBody.verdict, "file_overlap");
 
   const listRes = await app.request(`/v1/designs?projectId=proj-1&sessionId=s1`, { headers: bearer(admin.token) });
   const listBody = (await listRes.json()) as { items: { id: string; status: string; touches: string[] }[] };
   const design = listBody.items.find((d) => d.id === designId);
-  assert.equal(design?.status, "open", "a warning-severity amend must not demote the design out of 'open'");
+  assert.equal(design?.status, "open", "a file_overlap amend must not demote the design out of 'open'");
   assert.deepEqual(design?.touches, ["a.ts", "shared.ts"], "the proposed scope still persists even though it's only a warning");
 
   // Found while updating twing-monitor for the severity split: since
@@ -2059,12 +2076,11 @@ test("POST /v1/designs/:id/amend: a warning-severity (tier 1 exact) amendment pe
   // at all -- design_amended's own event only ever carries the scope
   // delta, never the check outcome.
   const activityRes = await app.request(`/v1/activity?projectId=proj-1&relatedId=${designId}`, { headers: bearer(admin.token) });
-  const activityBody = (await activityRes.json()) as { items: { kind: string; payload?: { verdict?: string; severity?: string } }[] };
+  const activityBody = (await activityRes.json()) as { items: { kind: string; payload?: { verdict?: string } }[] };
   const checked = activityBody.items.find((e) => e.kind === "design_checked");
-  assert.ok(checked, "a warning-severity amend must still log a design_checked event explaining why");
-  assert.equal(checked!.payload?.verdict, "overlap");
-  assert.equal(checked!.payload?.severity, "warning");
-  assert.ok(!activityBody.items.some((e) => e.kind === "design_flagged"), "a warning-severity amend must not also log design_flagged");
+  assert.ok(checked, "a file_overlap amend must still log a design_checked event explaining why");
+  assert.equal(checked!.payload?.verdict, "file_overlap");
+  assert.ok(!activityBody.items.some((e) => e.kind === "design_flagged"), "a file_overlap amend must not also log design_flagged");
 });
 
 test("POST /v1/designs/:id/amend: a rejected amend's proposed scope survives an approved review -- decideReview reopens it intact, not empty-handed", async () => {
@@ -2120,8 +2136,8 @@ test("POST /v1/designs/:id/amend: an approved review waives only that specific c
   // the same design.
   const { app, dataDir, constraints } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
-  constraints.add("proj-1", "needs review A", ["a/**"], "review_required", "seeded");
-  constraints.add("proj-1", "needs review B", ["b/**"], "review_required", "seeded");
+  constraints.add("proj-1", "needs review A", ["a/**"], "constraint", "seeded");
+  constraints.add("proj-1", "needs review B", ["b/**"], "constraint", "seeded");
 
   const registerRes = await app.request("/v1/designs/check", {
     method: "POST",
@@ -2135,7 +2151,7 @@ test("POST /v1/designs/:id/amend: an approved review waives only that specific c
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ addTouches: ["a/one.ts"] }),
   });
-  assert.equal((await firstAmend.json() as { verdict: string }).verdict, "constraint_flag");
+  assert.equal((await firstAmend.json() as { verdict: string }).verdict, "constraint_violation");
 
   const resolveRes = await app.request(`/v1/designs/${designId}/resolve`, {
     method: "POST",
@@ -2164,7 +2180,7 @@ test("POST /v1/designs/:id/amend: an approved review waives only that specific c
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ addTouches: ["b/one.ts"] }),
   });
-  assert.equal((await thirdAmend.json() as { verdict: string }).verdict, "constraint_flag", "b/** was never justified -- approving a/** must not waive it too");
+  assert.equal((await thirdAmend.json() as { verdict: string }).verdict, "constraint_violation", "b/** was never justified -- approving a/** must not waive it too");
 });
 
 test("POST /v1/designs/:id/resolve: an approved structural overlap on one path doesn't re-flag on a later amend, but a newly-added overlapping path on the same pair still flags fresh (item 7's fix)", async () => {
@@ -2185,7 +2201,7 @@ test("POST /v1/designs/:id/resolve: an approved structural overlap on one path d
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["file1.ts"], dependsOn: [] }),
   });
   const { verdict: firstVerdict, designId } = (await registerRes.json()) as { verdict: string; designId: string };
-  assert.equal(firstVerdict, "overlap", "sanity: file1.ts overlap must be caught first");
+  assert.equal(firstVerdict, "file_overlap", "sanity: file1.ts overlap must be caught first");
 
   const resolveRes = await app.request(`/v1/designs/${designId}/resolve`, {
     method: "POST",
@@ -2209,7 +2225,7 @@ test("POST /v1/designs/:id/resolve: an approved structural overlap on one path d
     body: JSON.stringify({ addTouches: ["file2.ts"] }),
   });
   const amendBody = (await amendRes.json()) as { verdict: string; conflicts: { overlapPaths: string[] }[] };
-  assert.equal(amendBody.verdict, "overlap", "file2.ts was never justified -- approving file1.ts must not waive it too");
+  assert.equal(amendBody.verdict, "file_overlap", "file2.ts was never justified -- approving file1.ts must not waive it too");
   assert.deepEqual(amendBody.conflicts[0].overlapPaths, ["file2.ts"], "file1.ts's already-approved overlap must not resurface");
 });
 
@@ -2217,8 +2233,8 @@ test("POST /v1/designs/:id/resolve: attributes constraintId even when the design
   // Regression test for a real bug found live, 2026-08-17: resolve() used
   // to derive constraintId by re-running the *overall* verdict check
   // (checkAmendedScope) and only attributing a constraint when that
-  // recomputed verdict came back exactly "constraint_flag". But
-  // runDesignChecks returns tier-1 "overlap" before it ever reaches
+  // recomputed verdict came back exactly "constraint_violation". But
+  // runDesignChecks returns tier-1 "file_overlap" before it ever reaches
   // tier-3's constraint match, so a design that both touches a flagged
   // path *and* happens to overlap some other open design on that same
   // path got constraintId silently dropped -- the approved review then had
@@ -2228,7 +2244,7 @@ test("POST /v1/designs/:id/resolve: attributes constraintId even when the design
   // design's own scope, independent of whatever else is open.
   const { app, dataDir, constraints } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
-  const constraint = constraints.add("proj-1", "needs review", ["shared.ts"], "review_required", "seeded");
+  const constraint = constraints.add("proj-1", "needs review", ["shared.ts"], "constraint", "seeded");
   const otherPat = await addProjectMember(app, admin.token, "proj-1"); // same-developer pairs no longer produce an overlap verdict at all (2026-08-22)
 
   // A second open design that also touches shared.ts -- this is what
@@ -2245,7 +2261,7 @@ test("POST /v1/designs/:id/resolve: attributes constraintId even when the design
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["shared.ts"], dependsOn: [] }),
   });
   const { verdict, designId } = (await registerRes.json()) as { verdict: string; designId: string };
-  assert.equal(verdict, "overlap", "sanity check: registration itself must see the overlap, not the constraint, since tier 1 wins");
+  assert.equal(verdict, "file_overlap", "sanity check: registration itself must see the overlap, not the constraint, since tier 1 wins");
 
   const resolveRes = await app.request(`/v1/designs/${designId}/resolve`, {
     method: "POST",
@@ -2471,7 +2487,7 @@ test("POST /v1/designs/:id/resume: a conflicting resume persists (identity reass
   await app.request("/v1/constraints/seed", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["constrained.ts"], type: "canonical_abstraction" }] }),
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["constrained.ts"], type: "constraint" }] }),
   });
   const firstRes = await app.request("/v1/designs/check", {
     method: "POST",
@@ -2486,9 +2502,8 @@ test("POST /v1/designs/:id/resume: a conflicting resume persists (identity reass
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ sessionId: "s1", addTouches: ["constrained.ts"] }),
   });
-  const resumeBody = (await resumeRes.json()) as { verdict: string; severity?: string };
-  assert.equal(resumeBody.verdict, "constraint_flag");
-  assert.equal(resumeBody.severity, "error", "sanity: must be error-severity, or this test isn't exercising the flagging path");
+  const resumeBody = (await resumeRes.json()) as { verdict: string };
+  assert.equal(resumeBody.verdict, "constraint_violation");
 
   // Demoted out of "dormant" into "flagged" -- addressable, not stuck --
   // with the resume's identity reassignment (sessionId) already applied,
@@ -2502,7 +2517,7 @@ test("POST /v1/designs/:id/resume: a conflicting resume persists (identity reass
 
 // 2026-08-19 severity split: same shape as above, but a warning-severity
 // (tier 1) resume must persist and reopen -- no flag, no review needed.
-test("POST /v1/designs/:id/resume: a warning-severity (tier 1 exact) resume persists and reopens as 'open'", async () => {
+test("POST /v1/designs/:id/resume: a file_overlap (tier 1 exact) resume persists and reopens as 'open'", async () => {
   const { app, dataDir, designs } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
   // Resume reassigns the design's developerId to whoever calls it (admin,
@@ -2530,22 +2545,20 @@ test("POST /v1/designs/:id/resume: a warning-severity (tier 1 exact) resume pers
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ sessionId: "s1" }),
   });
-  const resumeBody = (await resumeRes.json()) as { verdict: string; severity?: string };
-  assert.equal(resumeBody.verdict, "overlap");
-  assert.equal(resumeBody.severity, "warning");
+  const resumeBody = (await resumeRes.json()) as { verdict: string };
+  assert.equal(resumeBody.verdict, "file_overlap");
 
   const listRes = await app.request(`/v1/designs?projectId=proj-1&sessionId=s1`, { headers: bearer(admin.token) });
   const listBody = (await listRes.json()) as { items: { id: string; status: string; sessionId: string }[] };
   const design = listBody.items.find((d) => d.id === designId);
-  assert.equal(design?.status, "open", "a warning-severity resume must reopen as 'open', not 'flagged'");
+  assert.equal(design?.status, "open", "a file_overlap resume must reopen as 'open', not 'flagged'");
 
   const activityRes = await app.request(`/v1/activity?projectId=proj-1&relatedId=${designId}`, { headers: bearer(admin.token) });
-  const activityBody = (await activityRes.json()) as { items: { kind: string; payload?: { verdict?: string; severity?: string } }[] };
+  const activityBody = (await activityRes.json()) as { items: { kind: string; payload?: { verdict?: string } }[] };
   const checked = activityBody.items.find((e) => e.kind === "design_checked");
-  assert.ok(checked, "a warning-severity resume must still log a design_checked event explaining why");
-  assert.equal(checked!.payload?.verdict, "overlap");
-  assert.equal(checked!.payload?.severity, "warning");
-  assert.ok(!activityBody.items.some((e) => e.kind === "design_flagged"), "a warning-severity resume must not also log design_flagged");
+  assert.ok(checked, "a file_overlap resume must still log a design_checked event explaining why");
+  assert.equal(checked!.payload?.verdict, "file_overlap");
+  assert.ok(!activityBody.items.some((e) => e.kind === "design_flagged"), "a file_overlap resume must not also log design_flagged");
   assert.equal(design?.sessionId, "s1");
 });
 
@@ -2781,7 +2794,7 @@ test("POST /v1/designs/check: a rawPlanText registration under a *different* ses
   const secondBody = (await second.json()) as { designId: string; verdict: string };
   assert.equal(second.status, 200);
   assert.notEqual(secondBody.designId, firstBody.designId, "a different session must not reregister another session's design");
-  assert.equal(secondBody.verdict, "overlap", "and correctly conflicts with it, same as any other pair of unrelated open designs");
+  assert.equal(secondBody.verdict, "file_overlap", "and correctly conflicts with it, same as any other pair of unrelated open designs");
 });
 
 test("POST /v1/designs/check: a structured (twing design register-style) call with no rawPlanText always creates a new row, even repeated in the same session", async () => {
@@ -2813,7 +2826,7 @@ test("POST /v1/designs/check: a structured (twing design register-style) call wi
 test("POST /v1/designs/check: a reregistered design keeps its justifiedConstraintIds -- an approved review survives the retry", async () => {
   const { app, dataDir, designs, constraints } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
-  constraints.add("proj-1", "review required for retry.ts", ["src/net/retry.ts"], "review_required", "seeded");
+  constraints.add("proj-1", "review required for retry.ts", ["src/net/retry.ts"], "constraint", "seeded");
   const planText = "Add a RetryPolicy class to src/net/retry.ts implementing exponential backoff with jitter for outbound HTTP calls.";
 
   const first = await app.request("/v1/designs/check", {
@@ -2822,7 +2835,7 @@ test("POST /v1/designs/check: a reregistered design keeps its justifiedConstrain
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s-plan", rawPlanText: planText, summary: "add retry policy", creates: [], touches: ["src/net/retry.ts"], dependsOn: [] }),
   });
   const firstBody = (await first.json()) as { designId: string; verdict: string };
-  assert.equal(firstBody.verdict, "constraint_flag");
+  assert.equal(firstBody.verdict, "constraint_violation");
 
   const resolveRes = await app.request(`/v1/designs/${firstBody.designId}/resolve`, {
     method: "POST",
@@ -2872,9 +2885,8 @@ test("POST /v1/designs/check: a structured register call blocks with has_open_de
     body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "second, different project entirely", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
   assert.equal(secondRes.status, 200);
-  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string; openDesigns?: { id: string }[]; severity?: string };
+  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string; openDesigns?: { id: string }[] };
   assert.equal(secondBody.verdict, "has_open_designs");
-  assert.equal(secondBody.severity, "error");
   assert.equal(secondBody.designId, undefined, "no row exists for this verdict yet");
   assert.ok(secondBody.openDesigns?.some((d) => d.id === firstId));
   assert.equal(designs.listByProject("proj-1").length, beforeCount, "no new row persisted anywhere");
@@ -3000,7 +3012,7 @@ test("no_auth mode: role-gated routes (review decide) succeed regardless of \"ro
   const seedRes = await app.request("/v1/constraints/seed", {
     method: "POST",
     headers: { "content-type": "application/json", ...dev },
-    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "needs review", scope: ["a.ts"], type: "review_required" }] }),
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "needs review", scope: ["a.ts"], type: "constraint" }] }),
   });
   assert.equal(seedRes.status, 200);
 
@@ -3010,7 +3022,7 @@ test("no_auth mode: role-gated routes (review decide) succeed regardless of \"ro
     body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
   });
   const { designId, verdict } = (await checkRes.json()) as { designId: string; verdict: string };
-  assert.equal(verdict, "constraint_flag");
+  assert.equal(verdict, "constraint_violation");
 
   const resolveRes = await app.request(`/v1/designs/${designId}/resolve`, {
     method: "POST",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -14,7 +14,7 @@ import { cors } from "hono/cors";
 import type { Claim, CallEdge, DesignStatement, DesignConstraintType, Finding } from "@twing/core";
 import { type Db, createDb } from "./db/client.js";
 import { Store } from "./store.js";
-import { runChecks } from "./checks.js";
+import { findClaimConflicts, type ClaimFindingMatch } from "./checks.js";
 import { DesignRegistry, ConstraintStore } from "./design-store.js";
 import {
   runDesignChecks,
@@ -31,7 +31,7 @@ import { extractDesign } from "./design-extract.js";
 import { checkSemanticConflict } from "./design-semantic-check.js";
 import { findDesignDivergences } from "./design-divergence.js";
 import { enrichReviews } from "./review-enrich.js";
-import { AlignmentThreadStore, buildAlignmentSummary } from "./alignment-store.js";
+import { AlignmentThreadStore, buildAlignmentSummary, type AlignmentSubKind } from "./alignment-store.js";
 import { DrizzleActivityLog, type ActivityEventKind } from "./activity-log.js";
 import { IdentityStore, type ResolvedIdentity, type InviteScope, type Role } from "./identity-store.js";
 import { fetchRepoPermissions } from "./github-client.js";
@@ -483,19 +483,22 @@ export function createApp(options: CreateAppOptions = {}) {
    * writeup.
    *
    * **2026-08-22: blocking.** A hit now also flags the candidate
-   * (`designs.flag(..., "conflict", ...)`) alongside the existing
+   * (`designs.flag(..., "llm_divergence", ...)`) alongside the existing
    * alignment-thread/notice/activity-log side effects -- see DesignVerdict's
-   * doc comment (core/types.ts) for why this is a distinct verdict from
-   * `"overlap"`. Deliberately *not* synchronous: this still runs after the
+   * doc comment (core/types.ts) for the full four-bucket model this belongs
+   * to. Deliberately *not* synchronous: this still runs after the
    * triggering response was already sent, so it can't deny the registration
    * itself (and a few files may already have been edited by the time it
    * lands) -- it flips the design's `status` to `"flagged"` so the *next*
    * `Edit`/`Write` in that session is denied by the existing, unchanged
-   * `/v1/designs/scope-match` check, same enforcement path `constraint_flag`
-   * and tier-4 `overlap` already use. Skips any `other.id` already in
-   * `current.justifiedConflicts` before even calling the LLM -- an approved
-   * justification must not just re-flag on the very next pass (mirrors how
-   * `structuralOverlaps` skips already-waived `justifiedOverlaps` paths).
+   * `/v1/designs/scope-match` check, same enforcement path `constraint_violation`
+   * and `symbol_conflict` already use. Unlike those two, an `llm_divergence`
+   * (and `symbol_conflict`) block is self-approvable -- see
+   * `/v1/designs/:id/resolve`'s auto-decide branch below. Skips any
+   * `other.id` already in `current.justifiedConflicts` before even calling
+   * the LLM -- an approved justification must not just re-flag on the very
+   * next pass (mirrors how `structuralOverlaps` skips already-waived
+   * `justifiedOverlaps` paths).
    */
   function runSemanticComparatorPass(candidateId: string, others: DesignStatement[]): void {
     const started = designs.get(candidateId);
@@ -512,9 +515,11 @@ export function createApp(options: CreateAppOptions = {}) {
         if (!result.conflict) continue;
         // `isValidResult` (design-semantic-check.ts) doesn't runtime-enforce
         // that a non-null `kind` accompanies `conflict: true` -- fall back to
-        // "tension" (the most generic category) rather than drop a genuine
-        // conflict signal over a model-schema inconsistency.
-        const category = result.kind ?? "tension";
+        // "tension" (the most generic sub-kind) rather than drop a genuine
+        // conflict signal over a model-schema inconsistency. `kind` is the
+        // detail label (`AlignmentSubKind`) under the `"llm_divergence"`
+        // bucket, not the thread's top-level category (2026-08-26).
+        const subKind = result.kind ?? "tension";
         const thread = alignmentThreads.findOrCreate({
           projectId: current.projectId,
           symbolIds: [], // no real symbol for a design-vs-design finding
@@ -522,8 +527,9 @@ export function createApp(options: CreateAppOptions = {}) {
           otherDeveloperId: other.developerId,
           designId: other.id,
           systemDescription: result.reason,
-          category,
-          summary: buildAlignmentSummary(category, other.summary, 0),
+          category: "llm_divergence",
+          subKind,
+          summary: buildAlignmentSummary(subKind, other.summary, 0),
           initiatingDesignId: current.id, // this path always has a real initiating design -- always resolvable
           ts: Date.now(),
         });
@@ -537,7 +543,7 @@ export function createApp(options: CreateAppOptions = {}) {
         });
         store.addNotice(current.developerId, result.reason, Date.now(), thread.id);
         store.addNotice(other.developerId, result.reason, Date.now(), thread.id);
-        designs.flag(current.id, "conflict", {
+        designs.flag(current.id, "llm_divergence", {
           conflicts: [
             {
               conflictingDesignId: other.id,
@@ -597,45 +603,75 @@ export function createApp(options: CreateAppOptions = {}) {
     const changed = store.upsert(projectId, claims, callEdges);
     const active = store.activeClaims(projectId);
     const edges = store.callEdgesFor(projectId);
-    const findings = runChecks(changed, active, edges);
 
-    // Cross-session design divergence (statefulness redesign, 2026-08): the
-    // first place a real Claim is checked against another session's
-    // self-reported open DesignStatement, not just against other designs'
-    // self-reported fields. Advisory only, same as every other finding here
-    // -- never a deny. Each match opens/reuses a persistent alignment
-    // thread (dedup handled by AlignmentThreadStore.findOrCreate) so both
-    // parties can reconcile asynchronously; the thread's id rides along on
-    // the Finding/Notice so `twing align respond` has something to point at.
+    // "symbol_conflict" (2026-08-26 terminology simplification -- see
+    // DesignVerdict's doc comment, core/types.ts): the one bucket sourced
+    // from real edits (Claims) rather than self-reported design scope.
+    // Three finding kinds feed it -- checks.ts's textual_overlap/
+    // contract_divergence (two developers' real edits colliding) and
+    // design-divergence.ts's design_divergence (a real edit landing inside
+    // another developer's *declared* scope, no code on their side yet).
+    // Always self-approvable (no third party's rule is being overridden,
+    // just a peer's work), and flags *both* sides whenever each has an
+    // open design at the time -- whichever side lacks one just gets the
+    // advisory notice below, same as it always has.
     const openDesignsForDivergence = designs.openDesigns(projectId);
-    const divergences = findDesignDivergences(changed, openDesignsForDivergence);
-    const divergenceFindings: Finding[] = divergences.map(({ finding, design }) => {
-      // Best-effort: the claiming developer's own open design, if they have
-      // one -- reused from the same list already fetched for the divergence
-      // check itself, no extra query. Genuinely absent (not a bug) when the
-      // edit had no design behind it at all -- `disable-gate`, or `Bash`,
-      // which skips both the gate and claim capture entirely
-      // (`wire-hooks.ts`'s matchers) -- see alignment-store.ts's
-      // `initiatingDesignId` doc comment.
-      const initiatingDesign = openDesignsForDivergence
-        .filter((d) => d.developerId === finding.developerId)
-        .sort((a, b) => b.lastActivityAt - a.lastActivityAt)[0];
+    const openDesignForDeveloper = (developerId: string): DesignStatement | undefined =>
+      openDesignsForDivergence.filter((d) => d.developerId === developerId).sort((a, b) => b.lastActivityAt - a.lastActivityAt)[0];
+
+    /** Flags whichever side(s) have an open design, opens/amends the
+     * shared alignment thread (the delivery mechanism for *why* each side
+     * is blocked), and returns the finding with its thread id attached.
+     * `designA`/`designB` may each independently be undefined -- a side
+     * with no open design simply can't be flagged, same as today. */
+    function recordSymbolConflict(finding: Finding, subKind: AlignmentSubKind, designA: DesignStatement | undefined, designB: DesignStatement | undefined): Finding {
+      for (const d of [designA, designB]) {
+        if (!d) continue;
+        const other = d === designA ? designB : designA;
+        designs.flag(d.id, "symbol_conflict", {
+          conflicts: other
+            ? [{ conflictingDesignId: other.id, agentLabel: other.agentLabel, overlapKind: "symbol", overlapDetail: finding.reason, conflictingSummary: other.summary, overlapPaths: [finding.symbolId] }]
+            : [],
+        });
+      }
       const thread = alignmentThreads.findOrCreate({
         projectId,
         symbolIds: [finding.symbolId],
         developerId: finding.developerId,
         otherDeveloperId: finding.otherDeveloperId,
-        designId: design.id,
+        designId: designB?.id,
         systemDescription: finding.reason,
-        category: "symbol_claim",
-        summary: buildAlignmentSummary("symbol_claim", design.summary, 1),
-        initiatingDesignId: initiatingDesign?.id,
+        category: "symbol_conflict",
+        subKind,
+        summary: buildAlignmentSummary(subKind, designB?.summary ?? "", 1),
+        initiatingDesignId: designA?.id,
         ts: finding.ts,
       });
       return { ...finding, threadId: thread.id };
-    });
+    }
 
-    const allFindings = [...findings, ...divergenceFindings];
+    const claimMatches: ClaimFindingMatch[] = findClaimConflicts(changed, active, edges);
+    const claimFindings: Finding[] = claimMatches.map((m) =>
+      recordSymbolConflict(
+        m.finding,
+        m.finding.kind === "contract_divergence" ? "contract_break" : "real_edit_collision",
+        openDesignForDeveloper(m.finding.developerId),
+        openDesignForDeveloper(m.finding.otherDeveloperId),
+      ),
+    );
+
+    // Cross-session design divergence (statefulness redesign, 2026-08): the
+    // first place a real Claim is checked against another session's
+    // self-reported open DesignStatement, not just against other designs'
+    // self-reported fields. `design` (the intruded scope's owner) is
+    // already resolved by findDesignDivergences itself, so it's used
+    // directly rather than re-resolved via openDesignForDeveloper.
+    const divergences = findDesignDivergences(changed, openDesignsForDivergence);
+    const divergenceFindings: Finding[] = divergences.map(({ finding, design }) =>
+      recordSymbolConflict(finding, "scope_intrusion", openDesignForDeveloper(finding.developerId), design),
+    );
+
+    const allFindings = [...claimFindings, ...divergenceFindings];
 
     console.log(
       `twing serve: project ${projectId.slice(0, 12)} -- received ${claims.length} claim(s), ${callEdges.length} edge(s) ` +
@@ -873,15 +909,15 @@ export function createApp(options: CreateAppOptions = {}) {
     // feature wrongly did. `groupId`/`force` are the two explicit escape
     // hatches: a caller who already knows which existing design this
     // continues, or one deliberately overriding, skips the check entirely.
-    // No row is created if this fires -- unlike overlap/constraint_flag,
-    // which register-then-flag, there's nothing yet worth flagging, so
-    // don't create the very clutter this exists to prevent.
+    // No row is created if this fires -- unlike file_overlap/
+    // constraint_violation, which register-then-flag, there's nothing yet
+    // worth flagging, so don't create the very clutter this exists to
+    // prevent.
     if (!body.rawPlanText && !body.groupId && !body.force) {
       const openForDeveloper = designs.openDesignsForDeveloper(identity.developerId, Date.now());
       if (openForDeveloper.length > 0) {
         return c.json({
           verdict: "has_open_designs",
-          severity: "error",
           openDesigns: openForDeveloper.map((d) => ({ id: d.id, projectId: d.projectId, summary: d.summary, lastActivityAt: d.lastActivityAt })),
         });
       }
@@ -928,7 +964,6 @@ export function createApp(options: CreateAppOptions = {}) {
       // response is sent.
       payload: {
         verdict: outcome.verdict,
-        severity: outcome.severity,
         conflictCount: outcome.conflicts.length,
         reregistered,
         summary: design.summary,
@@ -937,18 +972,20 @@ export function createApp(options: CreateAppOptions = {}) {
       },
     });
 
-    // §17 scope enforcement (2026-08): a non-clean, error-severity verdict
-    // demotes the design out of "open" immediately -- before this response
-    // is ever sent -- so it stops counting as a usable open design for the
+    // §17 scope enforcement (2026-08): a blocking verdict demotes the
+    // design out of "open" immediately -- before this response is ever
+    // sent -- so it stops counting as a usable open design for the
     // Edit/Write gate's own-session check (`/v1/designs/scope-match`
     // below), rather than staying "open" until someone resolves it.
     //
-    // 2026-08-19, severity split: a `"warning"` verdict (tier 1's
-    // exactOverlap only, currently) deliberately skips this -- the design
-    // stays "open" so nothing downstream blocks. The conflict is still
-    // fully recorded above (activity log) and in the response below; it's
+    // 2026-08-26: whether a verdict blocks is now a pure function of the
+    // verdict itself, not a separately-tracked severity -- `"file_overlap"`
+    // (the only verdict `runDesignChecks` can return besides
+    // `"constraint_violation"`/`"clean"`) never blocks; `"clean"` obviously
+    // doesn't either. The conflict is still fully recorded above (activity
+    // log) and in the response below either way; for `"file_overlap"` it's
     // display-only, not gate-relevant.
-    if (outcome.verdict !== "clean" && outcome.severity === "error") {
+    if (outcome.verdict === "constraint_violation") {
       designs.flag(design.id, outcome.verdict, { conflicts: outcome.conflicts, constraints: outcome.constraints });
     }
 
@@ -1003,16 +1040,15 @@ export function createApp(options: CreateAppOptions = {}) {
     if (outcome.verdict === "clean") {
       return c.json({ verdict: "clean", designId: design.id, groupId: design.groupId });
     }
-    if (outcome.verdict === "constraint_flag") {
+    if (outcome.verdict === "constraint_violation") {
       return c.json({
-        verdict: "constraint_flag",
+        verdict: "constraint_violation",
         designId: design.id,
         groupId: design.groupId,
         constraints: outcome.constraints,
-        severity: outcome.severity,
       });
     }
-    return c.json({ verdict: "overlap", designId: design.id, groupId: design.groupId, conflicts: outcome.conflicts, severity: outcome.severity });
+    return c.json({ verdict: "file_overlap", designId: design.id, groupId: design.groupId, conflicts: outcome.conflicts });
   });
 
   // §17.5: adopt the conflicting design (superseded), or justify diverging
@@ -1074,16 +1110,48 @@ export function createApp(options: CreateAppOptions = {}) {
     // Semantic comparator's counterpart to overlapWaivers above (2026-08-22):
     // no cheap live recompute here (that would mean a second synchronous LLM
     // call inside this route) -- instead, read back which other designs this
-    // one currently has an *open* alignment thread against with this design
-    // as the `symbolId` (the same dedup key `runSemanticComparatorPass` uses
-    // when it calls `alignmentThreads.findOrCreate`), since that call runs
-    // unconditionally for every conflicting `other`, unlike `designs.flag()`
-    // itself which no-ops (and so drops the detail) once already flagged.
-    // See PendingReview.conflictWaivers' own doc comment (@twing/core).
+    // one currently has an *open* `llm_divergence` alignment thread against,
+    // filtered by `initiatingDesignId` (this design's own open design,
+    // stamped when `runSemanticComparatorPass` calls `findOrCreate` --
+    // `designs.flag()` only ever flags the *initiator* of a given comparator
+    // pass, never the design it was compared against, so `initiatingDesignId`
+    // is the only field that correctly identifies "this design is the one
+    // that got flagged here").
+    //
+    // 2026-08-26 fix: this used to filter on `t.symbolId === design.id`,
+    // matching `AlignmentThread.symbolId`'s doc comment calling it a
+    // "legacy...design-id-stand-in field" -- true before `initiatingDesignId`
+    // existed, when `symbolId` was overloaded to carry a design id for a
+    // symbol-less design-vs-design finding. `runSemanticComparatorPass`
+    // always passes `symbolIds: []` now, so `thread.symbolId` is always `""`
+    // for these threads and this comparison could never match -- confirmed
+    // dead since `initiatingDesignId` shipped: no llm_divergence resolve has
+    // ever actually populated `conflictWaivers`, so `justifiedConflicts`
+    // never got the approved design id and the semantic comparator kept
+    // re-flagging the same pair after every approval. Caught while adding
+    // `symbolConflictWaivers` below, which needed the same read-back and
+    // would otherwise have copied the same dead pattern next to a working
+    // one. See PendingReview.conflictWaivers' own doc comment (@twing/core).
     const conflictWaivers = alignmentThreads
       .listByProject(design.projectId, "open")
-      .filter((t) => t.symbolId === design.id && t.designId)
+      .filter((t) => t.category === "llm_divergence" && t.initiatingDesignId === design.id && t.designId)
       .map((t) => ({ conflictingDesignId: t.designId! }));
+    // `symbolConflictWaivers` (2026-08-26, new bucket): unlike llm_divergence
+    // above, a `symbol_conflict` finding can flag *both* sides independently
+    // (`recordSymbolConflict`, app.ts's `/v1/claims` handler) -- so this
+    // design can show up either as the initiator (`initiatingDesignId`) or
+    // as the referenced other side (`designId`) of a thread that flagged it.
+    // `symbolIds` on the thread is the accumulated set of real edits that
+    // collided; that's exactly what `DesignRegistry.decideReview` needs to
+    // build `justifiedSymbolConflicts`' composite waiver keys.
+    const symbolConflictWaivers = alignmentThreads
+      .listByProject(design.projectId, "open")
+      .filter((t) => t.category === "symbol_conflict" && (t.initiatingDesignId === design.id || t.designId === design.id))
+      .map((t) => ({
+        conflictingDesignId: (t.initiatingDesignId === design.id ? t.designId : t.initiatingDesignId)!,
+        symbolIds: t.symbolIds,
+      }))
+      .filter((w) => w.conflictingDesignId);
     const review = designs.addReview(
       id,
       design.projectId,
@@ -1091,8 +1159,22 @@ export function createApp(options: CreateAppOptions = {}) {
       constraintHits.map((h) => h.id),
       overlapWaivers,
       conflictWaivers.length > 0 ? conflictWaivers : undefined,
+      symbolConflictWaivers.length > 0 ? symbolConflictWaivers : undefined,
     );
     console.log(`twing serve: design ${id.slice(0, 8)} justified divergence -> pending review ${review.id.slice(0, 8)}`);
+    // 2026-08-26 self-approve: a review that carries no constraint hit at
+    // all is never overriding a third party's rule (constraint_violation is
+    // the only bucket where "whoever's authority you'd be overriding" is
+    // the project admin) -- so decide it immediately rather than waiting on
+    // `POST /v1/reviews/:id/decide`. `decideReview` still runs its normal
+    // approve path (unions the waivers into the design's justified* fields,
+    // reopens the design), so a repeat of the same conflict after this
+    // still gets suppressed the same way an admin-approved review always
+    // has.
+    if (constraintHits.length === 0) {
+      designs.decideReview(review.id, "approve");
+      return c.json({ status: "resolved", reviewId: review.id });
+    }
     return c.json({ status: "pending_review", reviewId: review.id });
   });
 
@@ -1181,19 +1263,21 @@ export function createApp(options: CreateAppOptions = {}) {
     if (!amended) return c.json({ error: `design is ${design.status}, not open -- can't amend` }, 409);
 
     if (outcome.verdict !== "clean") {
-      // 2026-08-19, severity split: only an error-severity verdict flags the
-      // design out of "open" -- a warning (tier 1 only) stays open, already
-      // persisted above via designs.amend, surfaced here for display only.
-      const action = outcome.severity === "error" ? "rejected" : "flagged (warning only)";
+      // 2026-08-26: blocking is now a static function of `verdict` alone
+      // (see DesignVerdict's doc comment, core/types.ts) -- `file_overlap`
+      // (tier 1) stays advisory, already persisted above via designs.amend,
+      // surfaced here for display only; `constraint_violation` (tier 3)
+      // always flags out of "open".
+      const action = outcome.verdict === "constraint_violation" ? "rejected" : "flagged (advisory only)";
       console.log(`twing serve: design ${id.slice(0, 8)} amend ${action} -> ${outcome.verdict}`);
       // Found while updating twing-monitor for the severity split: a
-      // warning-severity amend previously left *no* activity record at all
-      // -- designs.flag()'s design_flagged event (the only place this
-      // outcome ever got logged) is now skipped for a warning on purpose,
-      // and designs.amend()'s own design_amended event only ever carries
-      // the scope delta, never the check outcome. Logged here unconditionally
+      // non-blocking amend previously left *no* activity record at all --
+      // designs.flag()'s design_flagged event (the only place this outcome
+      // ever got logged) is skipped when nothing gets flagged, and
+      // designs.amend()'s own design_amended event only ever carries the
+      // scope delta, never the check outcome. Logged here unconditionally
       // (matching registration's own design_checked, which fires regardless
-      // of verdict) so both severities leave a "why" a viewer can find.
+      // of verdict) so both cases leave a "why" a viewer can find.
       activityLog.append({
         projectId: design.projectId,
         developerId: identity.developerId,
@@ -1203,17 +1287,16 @@ export function createApp(options: CreateAppOptions = {}) {
         ts: Date.now(),
         payload: {
           verdict: outcome.verdict,
-          severity: outcome.severity,
           summary: amended.summary,
           ...(outcome.conflicts.length > 0 ? { conflicts: outcome.conflicts } : {}),
           ...(outcome.constraints.length > 0 ? { constraints: outcome.constraints } : {}),
         },
       });
-      if (outcome.severity === "error") {
+      if (outcome.verdict === "constraint_violation") {
         designs.flag(id, outcome.verdict, { conflicts: outcome.conflicts, constraints: outcome.constraints });
       }
       runSemanticComparatorPass(id, open);
-      return c.json({ verdict: outcome.verdict, designId: id, groupId: amended.groupId, conflicts: outcome.conflicts, constraints: outcome.constraints, severity: outcome.severity });
+      return c.json({ verdict: outcome.verdict, designId: id, groupId: amended.groupId, conflicts: outcome.conflicts, constraints: outcome.constraints });
     }
 
     console.log(`twing serve: design ${id.slice(0, 8)} amended -> scopeVersion ${amended.scopeVersion}`);
@@ -1266,11 +1349,12 @@ export function createApp(options: CreateAppOptions = {}) {
     if (!resumed) return c.json({ error: `design is ${design.status}, not dormant -- can't resume` }, 409);
 
     if (outcome.verdict !== "clean") {
-      // Same severity split as amend above -- a warning stays "open"
-      // (designs.resume already persisted it above), only an error flags.
-      const action = outcome.severity === "error" ? "rejected" : "flagged (warning only)";
+      // Same 2026-08-26 static-per-verdict blocking as amend above -- a
+      // `file_overlap` stays "open" (designs.resume already persisted it
+      // above), only `constraint_violation` flags.
+      const action = outcome.verdict === "constraint_violation" ? "rejected" : "flagged (advisory only)";
       console.log(`twing serve: design ${id.slice(0, 8)} resume ${action} -> ${outcome.verdict}`);
-      // Same activity-trail gap as amend above -- a warning-severity resume
+      // Same activity-trail gap as amend above -- a non-blocking resume
       // previously left no record at all of what it found, since
       // design_flagged is skipped and design_resume's own event (below)
       // doesn't carry verdict/conflicts.
@@ -1283,17 +1367,16 @@ export function createApp(options: CreateAppOptions = {}) {
         ts: Date.now(),
         payload: {
           verdict: outcome.verdict,
-          severity: outcome.severity,
           summary: resumed.summary,
           ...(outcome.conflicts.length > 0 ? { conflicts: outcome.conflicts } : {}),
           ...(outcome.constraints.length > 0 ? { constraints: outcome.constraints } : {}),
         },
       });
-      if (outcome.severity === "error") {
+      if (outcome.verdict === "constraint_violation") {
         designs.flag(id, outcome.verdict, { conflicts: outcome.conflicts, constraints: outcome.constraints });
       }
       runSemanticComparatorPass(id, open);
-      return c.json({ verdict: outcome.verdict, designId: id, conflicts: outcome.conflicts, constraints: outcome.constraints, severity: outcome.severity });
+      return c.json({ verdict: outcome.verdict, designId: id, conflicts: outcome.conflicts, constraints: outcome.constraints });
     }
 
     console.log(`twing serve: design ${id.slice(0, 8)} resumed by ${identity.developerId.slice(0, 12)}/${body.sessionId.slice(0, 12)}`);
@@ -1394,7 +1477,22 @@ export function createApp(options: CreateAppOptions = {}) {
     // deny telling you to run `twing design resolve`, even right after
     // you'd already done so.
     const flaggedDesign = sessionDesigns[sessionDesigns.length - 1];
-    return c.json({ state: "flagged", designId: flaggedDesign.id, pendingReview: designs.hasPendingReview(flaggedDesign.id) });
+    // requiresAdmin (2026-08-26): which of the two self-approvable buckets
+    // vs. the one admin-gated bucket actually flagged this design --
+    // `designs.flag()` doesn't stamp `verdict` onto the design row itself
+    // (it's a `status` transition, not a field), so the only record of it
+    // is the `design_flagged` activity event's own payload. Read back the
+    // most recent one (a design can be flagged more than once across its
+    // lifetime -- amend, a later semantic-comparator pass, etc.) rather
+    // than the first, since only the *current* flag is what's actually
+    // blocking right now. Lets the Go hook's deny message tell "justify it
+    // and you're unblocked immediately" apart from "this goes to a project
+    // admin" instead of always saying the latter -- see DesignVerdict's doc
+    // comment (core/types.ts) for the full four-bucket model.
+    const flagEvents = activityLog.eventsForRelatedId(flaggedDesign.id).filter((e) => e.kind === "design_flagged");
+    const latestFlagVerdict = flagEvents.length > 0 ? (flagEvents[flagEvents.length - 1].payload as { verdict?: string } | undefined)?.verdict : undefined;
+    const requiresAdmin = latestFlagVerdict === "constraint_violation";
+    return c.json({ state: "flagged", designId: flaggedDesign.id, pendingReview: designs.hasPendingReview(flaggedDesign.id), requiresAdmin });
   });
 
   // §17.5: the human-facing queue -- justified divergences pending sign-off.
@@ -1539,9 +1637,11 @@ export function createApp(options: CreateAppOptions = {}) {
       return c.json({ error: "not an admin of this project -- constraint changes to an existing project require admin role" }, 403);
     }
 
-    const added = body.constraints.map((entry) =>
-      constraintStore.add(projectId, entry.statement, entry.scope, entry.type ?? "canonical_abstraction", "seeded"),
-    );
+    // 2026-08-26: `entry.type` is accepted on the wire for backward
+    // compatibility (old CLI builds still send it) but no longer branches
+    // on anything -- `DesignConstraintType` collapsed to the single value
+    // "constraint" (see DesignVerdict's doc comment in core/types.ts).
+    const added = body.constraints.map((entry) => constraintStore.add(projectId, entry.statement, entry.scope, "constraint", "seeded"));
     return c.json({ seeded: added.length });
   });
 

--- a/packages/server/src/checks.ts
+++ b/packages/server/src/checks.ts
@@ -1,16 +1,32 @@
 /**
- * Divergence detection — the v0 checks (§12). Runs "against everything
- * currently active in the project" but is invoked per just-submitted claim,
- * which is equivalent in effect: any divergence not touching a new claim
- * would already have been found and reported when its other side first
- * arrived. Row 3 (opposite-direction design) has no tractable deterministic
- * method yet and is explicitly out of scope for v0 (§12).
+ * Divergence detection — the v0 checks (§12), and (as of the 2026-08-26
+ * terminology simplification) one of the three real-edit sources that feed
+ * the `"symbol_conflict"` bucket (see `DesignVerdict`'s doc comment in
+ * core/types.ts) alongside `design-divergence.ts`'s `findDesignDivergences`.
+ * Runs "against everything currently active in the project" but is invoked
+ * per just-submitted claim, which is equivalent in effect: any divergence
+ * not touching a new claim would already have been found and reported when
+ * its other side first arrived. Row 3 (opposite-direction design) has no
+ * tractable deterministic method yet and is explicitly out of scope for v0
+ * (§12).
  */
 
 import type { Claim, CallEdge, Finding } from "@twing/core";
 
 function finding(kind: Finding["kind"], projectId: string, symbolId: string, developerId: string, otherDeveloperId: string, reason: string, ts: number): Finding {
   return { kind, projectId, symbolId, developerId, otherDeveloperId, reason, ts };
+}
+
+/** A `checks.ts` finding paired with each side's `sessionId` -- `app.ts`
+ * needs this (not just the flat `Finding`) to resolve each side's own
+ * currently-open design for `"symbol_conflict"` flagging, since a design is
+ * looked up by `(sessionId, developerId)`, and `Finding` itself carries
+ * neither. `sessionIdA` is the session behind `finding.developerId`;
+ * `sessionIdB` is the session behind `finding.otherDeveloperId`. */
+export interface ClaimFindingMatch {
+  finding: Finding;
+  sessionIdA: string;
+  sessionIdB: string;
 }
 
 /** Check 1: another active write claim on the same symbol from a different
@@ -24,14 +40,14 @@ function finding(kind: Finding["kind"], projectId: string, symbolId: string, dev
  * design-checks.ts's top-of-file comment for the full reasoning; a
  * dedicated same-developer-multi-agent-drift feature is deferred, not
  * rebuilt as a quieter variant of this one. */
-function textualOverlap(claim: Claim, active: Claim[], now: number): Finding[] {
+function textualOverlap(claim: Claim, active: Claim[], now: number): ClaimFindingMatch[] {
   if (claim.kind !== "write") return [];
-  const findings: Finding[] = [];
+  const matches: ClaimFindingMatch[] = [];
   for (const other of active) {
     if (other === claim) continue;
     if (other.symbolId === claim.symbolId && other.kind === "write" && other.sessionId !== claim.sessionId && other.developerId !== claim.developerId) {
-      findings.push(
-        finding(
+      matches.push({
+        finding: finding(
           "textual_overlap",
           claim.projectId,
           claim.symbolId,
@@ -40,10 +56,12 @@ function textualOverlap(claim: Claim, active: Claim[], now: number): Finding[] {
           `Another active session (developer ${other.developerId}) is also writing to ${claim.symbolId}.`,
           now,
         ),
-      );
+        sessionIdA: claim.sessionId,
+        sessionIdB: other.sessionId,
+      });
     }
   }
-  return findings;
+  return matches;
 }
 
 /**
@@ -55,16 +73,16 @@ function textualOverlap(claim: Claim, active: Claim[], now: number): Finding[] {
  * doc's own §7 framing ("developer A learns about a conflict that only
  * became visible when developer B pushed later") requires this either way.
  */
-function contractDivergence(claim: Claim, active: Claim[], edges: CallEdge[], now: number): Finding[] {
-  const findings: Finding[] = [];
+function contractDivergence(claim: Claim, active: Claim[], edges: CallEdge[], now: number): ClaimFindingMatch[] {
+  const matches: ClaimFindingMatch[] = [];
 
   if (claim.signatureChanged) {
     const callers = edges.filter((e) => e.calleeSymbolId === claim.symbolId).map((e) => e.callerSymbolId);
     for (const caller of callers) {
       const callerClaims = active.filter((a) => a.symbolId === caller && a.developerId !== claim.developerId);
       if (callerClaims.length > 0) {
-        findings.push(
-          finding(
+        matches.push({
+          finding: finding(
             "contract_divergence",
             claim.projectId,
             claim.symbolId,
@@ -73,7 +91,9 @@ function contractDivergence(claim: Claim, active: Claim[], edges: CallEdge[], no
             `Signature of ${claim.symbolId} changed; ${caller} (active claim from developer ${callerClaims[0].developerId}) calls it.`,
             now,
           ),
-        );
+          sessionIdA: claim.sessionId,
+          sessionIdB: callerClaims[0].sessionId,
+        });
       }
     }
   }
@@ -82,8 +102,8 @@ function contractDivergence(claim: Claim, active: Claim[], edges: CallEdge[], no
   for (const callee of callees) {
     const calleeClaims = active.filter((a) => a.symbolId === callee && a.signatureChanged && a.developerId !== claim.developerId);
     if (calleeClaims.length > 0) {
-      findings.push(
-        finding(
+      matches.push({
+        finding: finding(
           "contract_divergence",
           claim.projectId,
           callee,
@@ -92,19 +112,29 @@ function contractDivergence(claim: Claim, active: Claim[], edges: CallEdge[], no
           `${claim.symbolId} calls ${callee}, whose signature changed (developer ${calleeClaims[0].developerId}).`,
           now,
         ),
-      );
+        sessionIdA: claim.sessionId,
+        sessionIdB: calleeClaims[0].sessionId,
+      });
     }
   }
 
-  return findings;
+  return matches;
+}
+
+/** Richer sibling of `runChecks` below -- carries each match's session
+ * pairing so `app.ts` can resolve and flag each side's own open design for
+ * `"symbol_conflict"`. `runChecks` stays the plain-`Finding[]` convenience
+ * wrapper for callers (tests, the simulator) that don't need that. */
+export function findClaimConflicts(newClaims: Claim[], active: Claim[], edges: CallEdge[]): ClaimFindingMatch[] {
+  const now = Date.now();
+  const matches: ClaimFindingMatch[] = [];
+  for (const claim of newClaims) {
+    matches.push(...textualOverlap(claim, active, now));
+    matches.push(...contractDivergence(claim, active, edges, now));
+  }
+  return matches;
 }
 
 export function runChecks(newClaims: Claim[], active: Claim[], edges: CallEdge[]): Finding[] {
-  const now = Date.now();
-  const findings: Finding[] = [];
-  for (const claim of newClaims) {
-    findings.push(...textualOverlap(claim, active, now));
-    findings.push(...contractDivergence(claim, active, edges, now));
-  }
-  return findings;
+  return findClaimConflicts(newClaims, active, edges).map((m) => m.finding);
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -160,6 +160,12 @@ export const designs = sqliteTable(
      * `conflictingDesignId`s (no paths -- a `"conflict"` verdict has none to
      * key on), defaults to "[]" for pre-existing rows via the migration. */
     justifiedConflicts: text("justified_conflicts").notNull().default("[]"),
+    /** `"symbol_conflict"`'s own approval memory (2026-08-26 terminology
+     * simplification) -- see `DesignStatement.justifiedSymbolConflicts`'s
+     * own doc comment (@twing/core) for why this is a separate field from
+     * `justifiedOverlaps` rather than reusing it. JSON string[] of
+     * `${conflictingDesignId}::${symbolId}` keys, defaults to "[]". */
+    justifiedSymbolConflicts: text("justified_symbol_conflicts").notNull().default("[]"),
   },
   (t) => [
     index("designs_project_id_idx").on(t.projectId),
@@ -200,6 +206,13 @@ export const pendingReviews = sqliteTable(
      * `{conflictingDesignId}[]`, defaults to "[]". See
      * PendingReview.conflictWaivers. */
     conflictWaivers: text("conflict_waivers").notNull().default("[]"),
+    /** `"symbol_conflict"`'s counterpart to `overlapWaivers` above
+     * (2026-08-26 terminology simplification) -- sourced the same way
+     * `conflictWaivers` is: read back from this design's open
+     * `category: "symbol_conflict"` alignment threads, not recomputed
+     * live. JSON `{conflictingDesignId, symbolIds}[]`, defaults to "[]".
+     * See PendingReview.symbolConflictWaivers. */
+    symbolConflictWaivers: text("symbol_conflict_waivers").notNull().default("[]"),
   },
   (t) => [index("pending_reviews_project_id_idx").on(t.projectId)],
 );
@@ -209,7 +222,7 @@ export const constraints = sqliteTable(
   {
     id: text("id").primaryKey(),
     projectId: text("project_id").notNull(),
-    type: text("type").notNull(), // DesignConstraintType
+    type: text("type").notNull(), // DesignConstraintType -- collapsed to a single value 2026-08-26, column kept (see the type's own doc comment)
     statement: text("statement").notNull(),
     scope: text("scope").notNull(), // JSON string[]
     source: text("source").notNull(),
@@ -264,7 +277,14 @@ export const alignmentThreads = sqliteTable(
     // are all nullable-or-defaulted so pre-existing rows keep reading
     // correctly -- every new row gets real values, nothing here is backfilled
     // onto old rows.
-    category: text("category"), // "duplication" | "contradictory_assumptions" | "tension" | "symbol_claim"
+    // 2026-08-26 terminology simplification: category collapsed to the two
+    // bucket names; the old four values (duplication/contradictory_assumptions/
+    // tension/symbol_claim) survive as subKind below, detail under the
+    // bucket rather than a competing top-level name. Pre-2026-08-26 rows
+    // keep their old category string unconverted -- see AlignmentCategory's
+    // own doc comment (alignment-store.ts).
+    category: text("category"), // "symbol_conflict" | "llm_divergence" (or a legacy pre-2026-08-26 value)
+    subKind: text("sub_kind"), // AlignmentSubKind -- undefined on any row that predates this column
     summary: text("summary"), // short list-view label, distinct from systemDescription's full text
     symbolIds: text("symbol_ids").notNull().default("[]"), // JSON string[] -- every overlapping path accumulated across amendments
     initiatingDesignId: text("initiating_design_id"), // the initiating developer's own open design, when one resolves

--- a/packages/server/src/design-checks.test.ts
+++ b/packages/server/src/design-checks.test.ts
@@ -29,40 +29,39 @@ function design(overrides: Partial<DesignStatement> = {}): DesignStatement {
     justifiedConstraintIds: [],
     justifiedOverlaps: [],
     justifiedConflicts: [],
+    justifiedSymbolConflicts: [],
     lastActivityAt: Date.now(),
     ...overrides,
   };
 }
 
-test("clean when no overlap, no constraint match, no similarity", () => {
+test("clean when no overlap, no constraint match", () => {
   const candidate = design({ id: "a", creates: ["Foo"], touches: ["src/foo.ts"] });
   const other = design({ id: "b", sessionId: "s2", creates: ["Bar"], touches: ["src/bar.ts"], summary: "totally unrelated" });
   const outcome = runDesignChecks(candidate, [other], []);
   assert.equal(outcome.verdict, "clean");
 });
 
-test("tier 1: exact creates overlap -> overlap verdict, warning severity", () => {
+test("tier 1: exact creates overlap -> file_overlap verdict (always advisory)", () => {
   const candidate = design({ id: "a", creates: ["RetryPolicy"] });
   const other = design({ id: "b", sessionId: "s2", developerId: "dev2", creates: ["RetryPolicy"] });
   const outcome = runDesignChecks(candidate, [other], []);
-  assert.equal(outcome.verdict, "overlap");
-  assert.equal(outcome.severity, "warning", "2026-08-19 severity split: tier 1 is display-only, never blocking");
+  assert.equal(outcome.verdict, "file_overlap");
   assert.equal(outcome.conflicts[0].overlapKind, "creates");
   assert.equal(outcome.conflicts[0].conflictingDesignId, "b");
 });
 
-test("tier 1: exact touches overlap -> overlap verdict, warning severity", () => {
+test("tier 1: exact touches overlap -> file_overlap verdict (always advisory)", () => {
   const candidate = design({ id: "a", touches: ["src/net/retry.ts"] });
   const other = design({ id: "b", sessionId: "s2", developerId: "dev2", touches: ["src/net/retry.ts"] });
   const outcome = runDesignChecks(candidate, [other], []);
-  assert.equal(outcome.verdict, "overlap");
-  assert.equal(outcome.severity, "warning");
+  assert.equal(outcome.verdict, "file_overlap");
   assert.equal(outcome.conflicts[0].overlapKind, "touches");
 });
 
 // 2026-08-22: same-developer pairs are excluded from every overlap/conflict
-// tier that compares two designs (tiers 1 and 4 here; design-divergence.ts
-// and checks.ts separately) -- see design-checks.ts's top-of-file comment.
+// tier that compares two designs (tier 1 here; design-divergence.ts and
+// checks.ts separately) -- see design-checks.ts's top-of-file comment.
 test("tier 1: no overlap verdict when the 'other' design belongs to the same developer", () => {
   const candidate = design({ id: "a", developerId: "dev1", creates: ["RetryPolicy"], touches: ["src/net/retry.ts"] });
   const other = design({ id: "b", sessionId: "s2", developerId: "dev1", creates: ["RetryPolicy"], touches: ["src/net/retry.ts"] });
@@ -89,8 +88,7 @@ test("tier 1: a waived path stays quiet, but a second, different path on the sam
   const otherWithBoth = design({ id: "b", sessionId: "s2", developerId: "dev2", creates: ["file1.ts", "file2.ts"], summary: "totally unrelated" });
   const waivedOnlyFile1 = design({ id: "a", creates: ["file1.ts", "file2.ts"], justifiedOverlaps: [overlapWaiverKey("b", "file1.ts")] });
   const outcome = runDesignChecks(waivedOnlyFile1, [otherWithBoth], []);
-  assert.equal(outcome.verdict, "overlap");
-  assert.equal(outcome.severity, "warning");
+  assert.equal(outcome.verdict, "file_overlap");
   assert.deepEqual(outcome.conflicts[0].overlapPaths, ["file2.ts"]);
 });
 
@@ -98,50 +96,32 @@ test("tier 1: a waiver against design B doesn't leak to design C sharing the sam
   const candidate = design({ id: "a", creates: ["file1.ts"], justifiedOverlaps: [overlapWaiverKey("b", "file1.ts")] });
   const designC = design({ id: "c", sessionId: "s3", developerId: "dev3", creates: ["file1.ts"], summary: "totally unrelated" });
   const outcome = runDesignChecks(candidate, [designC], []);
-  assert.equal(outcome.verdict, "overlap");
-  assert.equal(outcome.severity, "warning");
+  assert.equal(outcome.verdict, "file_overlap");
   assert.equal(outcome.conflicts[0].conflictingDesignId, "c");
 });
 
-test("tier 3: constraint scope match -> constraint_flag", () => {
+test("tier 3: constraint scope match -> constraint_violation", () => {
   const candidate = design({ id: "a", touches: ["src/net/retry.ts"] });
   const constraint: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "canonical_abstraction",
+    type: "constraint",
     statement: "use net/retry.ts, don't add another",
     scope: ["src/net/**"],
     source: "seeded",
     createdAt: Date.now(),
   };
   const outcome = runDesignChecks(candidate, [], [constraint]);
-  assert.equal(outcome.verdict, "constraint_flag");
-  assert.equal(outcome.severity, "error");
+  assert.equal(outcome.verdict, "constraint_violation");
   assert.equal(outcome.constraints[0]?.statement, constraint.statement);
 });
 
-test("tier 4: summary similarity fallback only fires when 1-3 found nothing", () => {
-  const candidate = design({ id: "a", summary: "adds a retry wrapper with exponential backoff for the payments client" });
-  const other = design({ id: "b", sessionId: "s2", developerId: "dev2", summary: "adds a retry wrapper with exponential backoff for the billing client" });
-  const outcome = runDesignChecks(candidate, [other], []);
-  assert.equal(outcome.verdict, "overlap");
-  assert.equal(outcome.severity, "warning", "2026-08-22: tier 4 demoted alongside tier 1 -- weakest-evidence tier, no path corroboration by construction");
-  assert.match(outcome.conflicts[0].overlapDetail, /similar/);
-});
-
-test("tier 4 does not fire below the similarity threshold", () => {
-  const candidate = design({ id: "a", summary: "adds a retry wrapper" });
-  const other = design({ id: "b", sessionId: "s2", developerId: "dev2", summary: "renames a css variable" });
-  const outcome = runDesignChecks(candidate, [other], []);
-  assert.equal(outcome.verdict, "clean");
-});
-
-test("tier 4: no overlap verdict when the similar-sounding 'other' design belongs to the same developer", () => {
-  const candidate = design({ id: "a", developerId: "dev1", summary: "adds a retry wrapper with exponential backoff for the payments client" });
-  const other = design({ id: "b", sessionId: "s2", developerId: "dev1", summary: "adds a retry wrapper with exponential backoff for the billing client" });
-  const outcome = runDesignChecks(candidate, [other], []);
-  assert.equal(outcome.verdict, "clean");
-});
+// 2026-08-26: tier 4 (summarySimilarity, the Jaccard fallback) was removed
+// entirely -- redundant now that "llm_divergence" (design-semantic-check.ts)
+// exists as the real, non-syntactic-guessing replacement. Two designs whose
+// *summaries* merely read as similar now correctly stay "clean" at this
+// syntactic layer; see design-eval-cases.ts's bonus-11 case for a case that
+// used to be a documented tier-4 false positive and now correctly passes.
 
 // §17.9: the ground-truth per-path check, independent of any DesignStatement
 // -- this is what backstops a review_required rule (e.g. packages/server/**)
@@ -151,7 +131,7 @@ test("matchConstraintsForPaths: matches a bare path against a constraint's scope
   const constraint: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "the hosted coordinator -- do not remove without sign-off",
     scope: ["packages/server/**"],
     source: "seeded",
@@ -160,14 +140,14 @@ test("matchConstraintsForPaths: matches a bare path against a constraint's scope
   const hits = matchConstraintsForPaths(["packages/server/src/app.ts"], [constraint]);
   assert.equal(hits.length, 1);
   assert.equal(hits[0]?.statement, constraint.statement);
-  assert.equal(hits[0]?.type, "review_required");
+  assert.equal(hits[0]?.type, "constraint");
 });
 
 test("matchConstraintsForPaths: no match returns an empty list", () => {
   const constraint: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "n/a",
     scope: ["packages/server/**"],
     source: "seeded",
@@ -185,7 +165,7 @@ test("matchConstraintsForPaths: fires even when the path was never declared by a
   const constraint: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "protected",
     scope: ["packages/server/**"],
     source: "seeded",
@@ -200,46 +180,46 @@ test("matchConstraintsForPaths: fires even when the path was never declared by a
 // different constraint, both come back from one call -- previously only the
 // higher-priority hit surfaced, and the second was only discoverable by
 // justifying the first and retrying. See matchConstraintsForPaths' own doc
-// comment.
+// comment. Order-independent (2026-08-26): sort was type-priority-then-
+// specificity; type priority is gone (DesignConstraintType collapsed to one
+// value), so which of these two sorts first is just an artifact of their
+// scope strings' lengths, not something this test should assert on.
 test("matchConstraintsForPaths: two different paths hitting two different constraints both come back in one call", () => {
-  const reviewRequired: DesignConstraint = {
+  const serverRule: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "the hosted coordinator -- do not remove without sign-off",
     scope: ["packages/server/**"],
     source: "seeded",
     createdAt: Date.now(),
   };
-  const canonicalAbstraction: DesignConstraint = {
+  const framingRule: DesignConstraint = {
     id: "c2",
     projectId: "p1",
-    type: "canonical_abstraction",
+    type: "constraint",
     statement: "use the shared frame codec; don't invent a second wire format",
     scope: ["packages/core/src/framing.ts"],
     source: "seeded",
     createdAt: Date.now(),
   };
-  const hits = matchConstraintsForPaths(
-    ["packages/server/src/app.ts", "packages/core/src/framing.ts"],
-    [canonicalAbstraction, reviewRequired],
-  );
-  assert.equal(hits.length, 2);
-  // review_required still sorts first (higher priority), even though
-  // canonical_abstraction was passed in first.
-  assert.equal(hits[0]?.id, "c1");
-  assert.equal(hits[1]?.id, "c2");
+  const hits = matchConstraintsForPaths(["packages/server/src/app.ts", "packages/core/src/framing.ts"], [framingRule, serverRule]);
+  assert.deepEqual(new Set(hits.map((h) => h.id)), new Set(["c1", "c2"]));
 });
 
-// Found live, 2026-08-11: a broad canonical_abstraction constraint on
-// packages/** was seeded before a narrower review_required rule on
+// Found live, 2026-08-11 (pre-2026-08-26 constraint-type collapse): a broad
+// constraint on packages/** was seeded before a narrower one on
 // packages/server/**, and the broad one won just by being first in the
-// array -- masking the more important sign-off requirement.
-test("matchConstraintsForPaths: review_required wins over canonical_abstraction even when the broader rule was seeded first", () => {
+// array -- masking the more important sign-off requirement. The original
+// fix ranked by type priority first, specificity second; type priority is
+// gone now (DesignConstraintType collapsed to one value), but the narrower
+// scope here already wins on specificity alone, so the expected outcome is
+// unchanged.
+test("matchConstraintsForPaths: the narrower/more specific rule wins even when the broader rule was seeded first", () => {
   const broad: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "canonical_abstraction",
+    type: "constraint",
     statement: "use the shared frame codec; don't invent a second wire format",
     scope: ["packages/**"],
     source: "seeded",
@@ -248,28 +228,27 @@ test("matchConstraintsForPaths: review_required wins over canonical_abstraction 
   const narrow: DesignConstraint = {
     id: "c2",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "the hosted coordinator -- do not remove without sign-off",
     scope: ["packages/server/**"],
     source: "seeded",
     createdAt: Date.now(),
   };
   const hits = matchConstraintsForPaths(["packages/server/src/app.ts"], [broad, narrow]);
-  assert.equal(hits[0]?.type, "review_required");
   assert.equal(hits[0]?.statement, narrow.statement);
 });
 
 // Deliberate behavior change (2026-08-22): the old single-hit version
-// suppressed the broader same-type rule via this same specificity
-// tie-break, since it only needed to pick one winner. Now that the
-// function returns every match, both come back -- the tie-break just
-// controls sort order (more specific first), not which one survives. See
-// matchConstraintsForPaths' own doc comment.
-test("matchConstraintsForPaths: among same-type matches, both come back, more specific (longer) scope sorted first", () => {
+// suppressed the broader rule via this same specificity tie-break, since it
+// only needed to pick one winner. Now that the function returns every
+// match, both come back -- the tie-break just controls sort order (more
+// specific first), not which one survives. See matchConstraintsForPaths'
+// own doc comment.
+test("matchConstraintsForPaths: both matches come back, more specific (longer) scope sorted first", () => {
   const wide: DesignConstraint = {
     id: "c1",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "wide rule",
     scope: ["packages/**"],
     source: "seeded",
@@ -278,7 +257,7 @@ test("matchConstraintsForPaths: among same-type matches, both come back, more sp
   const specific: DesignConstraint = {
     id: "c2",
     projectId: "p1",
-    type: "review_required",
+    type: "constraint",
     statement: "specific rule",
     scope: ["packages/server/**"],
     source: "seeded",

--- a/packages/server/src/design-checks.ts
+++ b/packages/server/src/design-checks.ts
@@ -1,7 +1,13 @@
 /**
- * Overlap detection (design doc §17.4 / spec §6) -- cheapest, highest-
- * precision first: exact overlap, then constraint match, then a Jaccard
- * summary-similarity fallback that only runs if those found nothing.
+ * Overlap detection (design doc §17.4 / spec §6) -- the synchronous half of
+ * the four-bucket design-conflict model (2026-08-26 terminology
+ * simplification; see `DesignVerdict`'s doc comment in core/types.ts for
+ * the full model). Two tiers now, cheapest first: exact `creates`/`touches`
+ * overlap (`"file_overlap"`, always advisory, never blocks), then
+ * constraint match (`"constraint_violation"`, always blocks). `"symbol_conflict"`
+ * (real-edit collisions, sourced from Claims) lives in `checks.ts`/
+ * `design-divergence.ts`; `"llm_divergence"` lives in
+ * `design-semantic-check.ts`'s async comparator -- neither runs here.
  *
  * (2026-08-19, removed: a "dependency collision" tier that used to sit
  * between exact overlap and constraint match -- one design's `creates`
@@ -18,65 +24,58 @@
  * different name). Kept for now: `exactOverlap` below (creates/touches
  * exact-match, the same brittleness, but a strictly more common phrasing
  * choice -- a file path is close to canonical even before it exists,
- * unlike a not-yet-decided symbol name) and the summary-similarity/
- * semantic-comparator layers, which are the intended home for anything
- * needing real conceptual matching rather than exact-string matching.
+ * unlike a not-yet-decided symbol name).
  *
- * (2026-08-19, severity split: `exactOverlap` (tier 1) demoted from
- * blocking to `severity: "warning"` -- a same-file coincidence flags for
- * display (design detail, activity feed) but no longer demotes the design
- * to `"flagged"` or denies the Edit/Write gate. `constraintMatch` (tier 3)
- * unchanged, still `severity: "error"`, still blocking. See DesignSeverity's
- * doc comment in core/types.ts.)
+ * (2026-08-19, `exactOverlap` demoted from blocking to advisory-only -- a
+ * same-file coincidence flags for display (design detail, activity feed)
+ * but never demotes the design to `"flagged"` or denies the Edit/Write
+ * gate. `constraintMatch` unchanged, still blocking.)
  *
- * (2026-08-22, `summarySimilarity` (tier 4) also demoted to `severity:
- * "warning"`: by construction it only ever runs once tier 1 has already
- * found *zero* path-level overlap (see the early return in
- * `runDesignChecks` below), so every tier-4 hit was blocking on unvalidated
- * Jaccard word-overlap of free text alone, with no path corroboration --
- * the weakest-evidence tier carrying the same blocking weight as an actual
- * constraint violation, and stronger weight than tier 1's own exact path
- * collision. Real conceptual-overlap enforcement now belongs to the
- * semantic comparator's own `"conflict"` verdict instead (see
- * `runSemanticComparatorPass` in app.ts, and DesignVerdict's doc comment in
- * core/types.ts) -- unlike this tier, that one is at least an LLM judgment
- * over the designs' actual text, not a bag-of-words heuristic, and it
- * blocks by flagging the design once its async check returns, rather than
- * synchronously here.)
+ * (2026-08-26, tier 4 -- the Jaccard summary-similarity fallback -- removed
+ * entirely, not just demoted. It only ever ran once tier 1 found *zero*
+ * path-level overlap, on unvalidated bag-of-words similarity of free text
+ * alone with no path corroboration, and by then was already redundant:
+ * `"llm_divergence"` (the semantic comparator, `design-semantic-check.ts`)
+ * is a strictly stronger signal for the same question -- an actual LLM
+ * judgment over the designs' text, not a word-overlap heuristic -- and is
+ * the bucket this kind of conceptual-overlap detection now belongs to
+ * exclusively. `DesignSeverity`/`severity` is gone from the whole model as
+ * of this same change: with tier 4 dropped and `DesignConstraintType`
+ * collapsed to one value, whether a verdict blocks is now a pure, static
+ * function of which verdict it is (`file_overlap` never does; the other
+ * three always do), so a separately-varying severity field had nothing
+ * left to vary.
  *
- * (2026-08-22, same-developer pairs excluded from tiers 1 and 4: a usability
- * pass on twing-monitor found overlap/conflict signal between a single
- * developer's own two designs -- the common case once one person runs
- * several concurrent agents/sessions -- was pure noise in the activity feed,
- * not just a false-positive-prone blocker. Checked against this project's
- * own live history: every alignment thread this project has ever opened
- * (14/14) was a self-pair, and none was ever replied to or closed.
- * `constraintMatch` (tier 3, see structuralOverlaps and runDesignChecks
- * below) is untouched -- it's a path-vs-project-rule check with no "other
- * developer" involved at all, so there's nothing to exclude. Reversed from
- * `design-divergence.ts`'s and `checks.ts`'s prior convention of
- * deliberately *including* a developer's own concurrent sessions (§8) --
- * that convention is reversed there too, same day, same reasoning. A
- * dedicated same-developer-multi-agent-drift feature is deferred, not
- * rebuilt as a quieter variant of this one -- see those files' own
- * comments.)
+ * (2026-08-22, same-developer pairs excluded from tier 1 (and, historically,
+ * the now-removed tier 4): a usability pass on twing-monitor found overlap/
+ * conflict signal between a single developer's own two designs -- the
+ * common case once one person runs several concurrent agents/sessions --
+ * was pure noise in the activity feed, not just a false-positive-prone
+ * blocker. Checked against this project's own live history: every
+ * alignment thread this project has ever opened (14/14) was a self-pair,
+ * and none was ever replied to or closed. `constraintMatch` (tier 3, see
+ * structuralOverlaps and runDesignChecks below) is untouched -- it's a
+ * path-vs-project-rule check with no "other developer" involved at all, so
+ * there's nothing to exclude. Reversed from `design-divergence.ts`'s and
+ * `checks.ts`'s prior convention of deliberately *including* a developer's
+ * own concurrent sessions (§8) -- that convention is reversed there too,
+ * same day, same reasoning. A dedicated same-developer-multi-agent-drift
+ * feature is deferred, not rebuilt as a quieter variant of this one -- see
+ * those files' own comments.)
  */
 
 import { minimatch } from "minimatch";
-import type { DesignStatement, DesignConstraint, DesignConflict, DesignVerdict, DesignConstraintType, DesignSeverity } from "@twing/core";
+import type { DesignStatement, DesignConstraint, DesignConflict, DesignVerdict, DesignConstraintType } from "@twing/core";
 
 export interface DesignCheckOutcome {
   verdict: DesignVerdict;
   conflicts: DesignConflict[];
-  /** Always present (mirrors `conflicts` above), not just on `constraint_flag`
-   * -- empty everywhere else. See matchConstraintsForPaths's doc comment for
-   * why this is a list now, not a single optional hit. */
+  /** Always present (mirrors `conflicts` above), not just on
+   * `constraint_violation` -- empty everywhere else. See
+   * matchConstraintsForPaths's doc comment for why this is a list now, not
+   * a single optional hit. */
   constraints: ConstraintHit[];
-  /** See DesignSeverity (core/types.ts). Undefined for `"clean"`. */
-  severity?: DesignSeverity;
 }
-
-const SUMMARY_SIMILARITY_THRESHOLD = 0.5;
 
 /** ExitPlanMode retry dedup (design-store.ts's `openPlanModeDesignForSession`
  * / `reregisterFromPlan`, wired in app.ts's `POST /v1/designs/check`):
@@ -84,12 +83,11 @@ const SUMMARY_SIMILARITY_THRESHOLD = 0.5;
  * `rawPlanExcerpt` before being treated as "the same plan, retried" (update
  * in place) rather than a genuinely different plan that happens to share a
  * session id (register as a new row, leaving the candidate untouched).
- * Deliberately a separate, independent constant from
- * `SUMMARY_SIMILARITY_THRESHOLD` above, not a reuse of it -- that one gates
- * a low-stakes advisory flag for a human to look at; a false positive here
- * would silently overwrite a different design's content, so a false match
- * is a correctness bug, not just a missed hint, and needs a different risk
- * calculus.
+ * Deliberately its own constant, not shared with anything in the
+ * design-conflict model above -- a false positive here would silently
+ * overwrite a different design's content, so a false match is a
+ * correctness bug, not just a missed hint, and needs a different risk
+ * calculus than any conflict-detection threshold.
  *
  * 0.7 -- tested empirically against real data rather than picked blind (see
  * the plan this shipped from): full, untruncated plan text on both sides
@@ -181,26 +179,21 @@ export interface ConstraintHit {
  * session's self-reported `creates`/`touches` claimed at registration time.
  * See §17.9.
  */
-// When several constraints match the same path, `review_required` outranks
-// `canonical_abstraction`/`domain_fact` regardless of scope width (a
-// sign-off requirement shouldn't get silently masked by a broader
-// duplicate-abstraction rule seeded earlier -- found live, 2026-08-11:
-// packages/server/** correctly matched, but the earlier, broader
-// packages/** "don't invent a second wire format" rule won the race and
-// reported instead, which is a misleading reason even though the deny
-// itself was still correct).
-const CONSTRAINT_TYPE_PRIORITY: Record<DesignConstraintType, number> = {
-  review_required: 0,
-  canonical_abstraction: 1,
-  domain_fact: 2,
-};
+// 2026-08-26: `CONSTRAINT_TYPE_PRIORITY` (a three-way priority map so a
+// `review_required` match always outranked `canonical_abstraction`/
+// `domain_fact` when several constraints hit the same path) is gone --
+// `DesignConstraintType` collapsed to a single value the same day, so
+// there's no longer more than one type to rank. Sort by scope-specificity
+// alone now (see matchConstraintsForPaths below); every matching constraint
+// is returned regardless of order (2026-08-22), so this only ever affects
+// display order among simultaneous hits, never which are included.
 
 /**
  * Returns *every* distinct constraint (deduped by id) that matches at least
  * one of `targets`, not just one "best" hit -- fixed 2026-08-22 (design-gate
  * friction item 8, found live shipping the constraint-deletion work
  * 2026-08-20): this used to collapse to a single winner by
- * `CONSTRAINT_TYPE_PRIORITY` then scope specificity, so a candidate whose
+ * constraint-type priority then scope specificity, so a candidate whose
  * paths violated two *different* constraints only ever saw the
  * higher-priority one -- justify-and-approve that one, retry, and only then
  * discover the second. Every consumer (runDesignChecks, `/v1/designs/check`
@@ -208,10 +201,11 @@ const CONSTRAINT_TYPE_PRIORITY: Record<DesignConstraintType, number> = {
  * threads a list through instead of a single optional hit. See design doc
  * §17.11.
  *
- * Still sorted `(CONSTRAINT_TYPE_PRIORITY asc, scope-specificity desc)` --
- * most-severe-and-specific first -- so a caller that only wants "the one
- * that matters most" can still just take `[0]` (e.g. design-eval.test.ts's
- * eval cases, which only ever expect one constraint per case).
+ * Sorted by scope-specificity alone (2026-08-26 -- was also ranked by
+ * constraint-type priority before `DesignConstraintType` collapsed to one
+ * value) -- most-specific first, so a caller that only wants "the one that
+ * matters most" can still just take `[0]` (e.g. design-eval.test.ts's eval
+ * cases, which only ever expect one constraint per case).
  *
  * Deliberate behavior change from the old single-hit version: two
  * *same-type* constraints both matching the same path (e.g. a broad
@@ -244,10 +238,7 @@ export function matchConstraintsForPaths(
     }
   }
 
-  hits.sort((a, b) => {
-    const byPriority = CONSTRAINT_TYPE_PRIORITY[a.constraint.type] - CONSTRAINT_TYPE_PRIORITY[b.constraint.type];
-    return byPriority !== 0 ? byPriority : b.scopeLength - a.scopeLength;
-  });
+  hits.sort((a, b) => b.scopeLength - a.scopeLength);
 
   return hits.map((h) => ({ id: h.constraint.id, statement: h.constraint.statement, type: h.constraint.type }));
 }
@@ -266,7 +257,8 @@ function keywordSet(s: string): Set<string> {
  * "the"/"and" don't -- doesn't materially inflate scores for unrelated
  * English text in practice, see `PLAN_RETRY_SIMILARITY_THRESHOLD`'s empirical
  * notes). Exported for reuse by the ExitPlanMode retry-dedup check
- * (design-store.ts / app.ts) as well as `summarySimilarity` below. */
+ * (design-store.ts / app.ts) -- its only consumer now that tier 4
+ * (`summarySimilarity`) has been removed (2026-08-26). */
 export function jaccard(a: string, b: string): number {
   const setA = keywordSet(a);
   const setB = keywordSet(b);
@@ -275,23 +267,6 @@ export function jaccard(a: string, b: string): number {
   for (const w of setA) if (setB.has(w)) intersectionSize++;
   const unionSize = new Set([...setA, ...setB]).size;
   return intersectionSize / unionSize;
-}
-
-/** Tier 4: deliberately weak fallback net, only consulted when 1-3 find
- * nothing (design doc §17.4 / spec §6.4). Non-blocking (2026-08-22, see this
- * file's header comment) -- Jaccard word-overlap on free text with no path
- * evidence isn't strong enough grounds to deny real work on its own. */
-function summarySimilarity(candidate: DesignStatement, other: DesignStatement): DesignConflict | undefined {
-  const score = jaccard(candidate.summary, other.summary);
-  if (score < SUMMARY_SIMILARITY_THRESHOLD) return undefined;
-  return {
-    conflictingDesignId: other.id,
-    agentLabel: other.agentLabel,
-    overlapKind: "touches",
-    overlapDetail: `summaries are ${Math.round(score * 100)}% similar by keyword overlap (fallback signal, low confidence)`,
-    conflictingSummary: other.summary,
-    overlapPaths: [], // no specific path -- this tier flags on summary text, not scope
-  };
 }
 
 /**
@@ -383,14 +358,17 @@ export function runDesignChecks(
 
   const structuralConflicts = structuralOverlaps(candidate, others);
   if (structuralConflicts.length > 0) {
-    // 2026-08-19: demoted to "warning" -- a same-file coincidence between
-    // two designs' self-reported creates/touches isn't itself evidence of a
-    // real merge conflict (a design can decline to actually write to a path
-    // it named, or write something that doesn't collide with what the
-    // other one wrote). Still worth surfacing before either writes code --
-    // that's the one thing this tier can do that claims (§4) can't, since
-    // claims don't exist until code does -- just not worth blocking on.
-    return { verdict: "overlap", conflicts: structuralConflicts, constraints: [], severity: "warning" };
+    // Always advisory (2026-08-19, renamed from "overlap" 2026-08-26) -- a
+    // same-file coincidence between two designs' self-reported
+    // creates/touches isn't itself evidence of a real merge conflict (a
+    // design can decline to actually write to a path it named, or write
+    // something that doesn't collide with what the other one wrote). Still
+    // worth surfacing before either writes code -- that's the one thing
+    // this tier can do that claims (§4) can't, since claims don't exist
+    // until code does -- just never worth blocking on. Real edits landing
+    // on the same real symbol is a different, blocking bucket --
+    // `"symbol_conflict"`, see checks.ts/design-divergence.ts.
+    return { verdict: "file_overlap", conflicts: structuralConflicts, constraints: [] };
   }
 
   // §17 review-flow fix (2026-08): a constraint already justified and
@@ -403,24 +381,7 @@ export function runDesignChecks(
   // see matchConstraintsForPaths's doc comment.)
   const constraintHits = constraintMatch(candidate, constraints);
   if (constraintHits.length > 0) {
-    return { verdict: "constraint_flag", conflicts: [], constraints: constraintHits, severity: "error" };
-  }
-
-  const similarityConflicts: DesignConflict[] = [];
-  for (const other of others) {
-    if (other.developerId === candidate.developerId) continue; // see structuralOverlaps's doc comment
-    const sim = summarySimilarity(candidate, other);
-    if (sim) similarityConflicts.push(sim);
-  }
-  if (similarityConflicts.length > 0) {
-    // Demoted alongside tier 1 (2026-08-22, see this file's header
-    // comment) -- a conceptual-overlap fallback with no specific colliding
-    // path to point at (see summarySimilarity's own comment) isn't strong
-    // enough evidence to block on its own. Real conceptual-conflict
-    // enforcement now belongs to the semantic comparator's own `"conflict"`
-    // verdict (app.ts's runSemanticComparatorPass), which blocks by
-    // flagging the design once its async LLM check returns.
-    return { verdict: "overlap", conflicts: similarityConflicts, constraints: [], severity: "warning" };
+    return { verdict: "constraint_violation", conflicts: [], constraints: constraintHits };
   }
 
   return { verdict: "clean", conflicts: [], constraints: [] };

--- a/packages/server/src/design-divergence.test.ts
+++ b/packages/server/src/design-divergence.test.ts
@@ -35,6 +35,7 @@ function makeDesign(overrides: Partial<DesignStatement> = {}): DesignStatement {
     justifiedConstraintIds: [],
     justifiedOverlaps: [],
     justifiedConflicts: [],
+    justifiedSymbolConflicts: [],
     lastActivityAt: 0,
     ...overrides,
   };

--- a/packages/server/src/design-divergence.ts
+++ b/packages/server/src/design-divergence.ts
@@ -9,12 +9,15 @@
  * register honest, non-overlapping designs and then silently drift into
  * each other's territory with nothing noticing.
  *
- * Deliberately async/advisory only (§4's model, not §17's blocking one):
- * this runs from `POST /v1/claims`, the same request that already runs
- * `checks.ts`'s divergence checks, and produces ordinary `Finding`s
- * delivered through the existing notice pipeline -- never a deny. Flag, not
- * punish: divergence is expected and fine, this is for visibility and
- * voluntary reconciliation (see `alignment-store.ts`), not enforcement.
+ * This module's `Finding`s are one of the three real-edit sources
+ * (alongside `checks.ts`'s `textual_overlap`/`contract_divergence`) that
+ * `app.ts`'s `POST /v1/claims` turns into a `"symbol_conflict"` block
+ * (2026-08-26 terminology simplification -- see `DesignVerdict`'s doc
+ * comment in core/types.ts). This module itself stays purely a detector --
+ * it still just returns `Finding`s and the matched `design`, same shape as
+ * before; the flagging/blocking decision lives entirely in `app.ts`, which
+ * is also what makes it self-approvable rather than admin-gated: no third
+ * party's rule is being overridden here, just a peer's declared scope.
  */
 
 import { minimatch } from "minimatch";

--- a/packages/server/src/design-eval-cases.ts
+++ b/packages/server/src/design-eval-cases.ts
@@ -46,6 +46,7 @@ export function design(overrides: Partial<DesignStatement> = {}): DesignStatemen
     justifiedConstraintIds: [],
     justifiedOverlaps: [],
     justifiedConflicts: [],
+    justifiedSymbolConflicts: [],
     lastActivityAt: Date.now(),
     ...overrides,
   };
@@ -56,7 +57,9 @@ export function constraint(overrides: Partial<DesignConstraint> = {}): DesignCon
   return {
     id: "c1",
     projectId: "p1",
-    type: "canonical_abstraction",
+    // 2026-08-26: DesignConstraintType collapsed to a single value -- see
+    // DesignVerdict's doc comment, core/types.ts.
+    type: "constraint",
     statement: "constraint statement",
     scope: [],
     source: "seeded",
@@ -161,7 +164,7 @@ export const EVAL_CASES: EvalCase[] = [
         summary: "Add a reusable retry policy class for outbound calls",
       }),
     ],
-    expectedVerdict: "overlap",
+    expectedVerdict: "file_overlap",
     expectedOverlapKind: "creates",
     futureLlmExpectation: "should_flag_as_conflict",
   },
@@ -191,7 +194,7 @@ export const EVAL_CASES: EvalCase[] = [
         summary: "Add a circuit breaker around retry.ts so it stops retrying after repeated failures and fails fast",
       }),
     ],
-    expectedVerdict: "overlap",
+    expectedVerdict: "file_overlap",
     expectedOverlapKind: "touches",
     futureLlmExpectation: "should_flag_as_conflict",
     planModeProvenance: {
@@ -264,14 +267,14 @@ export const EVAL_CASES: EvalCase[] = [
     constraints: [
       constraint({
         id: "constraint-review-required",
-        type: "review_required",
+        type: "constraint",
         statement:
           "packages/server/**, especially design-*.ts/identity-store.ts -- a bug in the verdict logic blocks real Edit/Write calls across every gated session",
         scope: ["packages/server/src/design-*.ts"],
       }),
     ],
-    expectedVerdict: "constraint_flag",
-    expectedConstraintType: "review_required",
+    expectedVerdict: "constraint_violation",
+    expectedConstraintType: "constraint",
     futureLlmExpectation: "should_flag_as_conflict",
   },
 
@@ -474,15 +477,28 @@ export const EVAL_CASES: EvalCase[] = [
   // its own bucket rather than only proving the near-miss
   // ---------------------------------------------------------------------
   {
+    // 2026-08-26: moved from `known_false_positive`/`expectedVerdict:
+    // "overlap"` to `disparate`/`expectedVerdict: "clean"` -- tier 4
+    // (summarySimilarity, the Jaccard fallback this case was written to
+    // document a false positive from) was removed entirely as part of the
+    // terminology simplification (design-checks.ts's header comment;
+    // llm_divergence, the semantic comparator, is the intended real
+    // replacement). Per this harness's own top-of-file rule ("if one of
+    // those [semantic_gap/known_false_positive] ever starts failing, that's
+    // good news... move the case... rather than deleting the assertion"),
+    // this case correctly staying clean now is the fix, not a regression --
+    // kept as permanent regression coverage that a future tier doesn't
+    // reintroduce the same over-fire.
     id: "bonus-11-known-false-positive-boilerplate-refactor",
-    bucket: "known_false_positive",
-    category: "tier4_boilerplate_false_positive",
+    bucket: "disparate",
+    category: "disparate_borderline_vocabulary",
     source: "manual",
     rationale:
-      "Near-boilerplate refactor phrasing this generic crosses tier 4's threshold trivially, even though the two " +
-      "designs are completely unrelated. design-checks.ts's own comment calls tier 4 a 'deliberately weak/low-" +
-      "confidence fallback' -- this case makes that concrete. Recorded as a currently-true false positive: the " +
-      "future LLM path's precision must not inherit it.",
+      "Near-boilerplate refactor phrasing this generic used to cross tier 4's Jaccard threshold trivially, even " +
+      "though the two designs are completely unrelated -- design-checks.ts's own comment called tier 4 a " +
+      "'deliberately weak/low-confidence fallback', and this case made that concrete as a known false positive. " +
+      "Tier 4 is gone as of 2026-08-26; this now correctly stays clean, and stays in the suite as a regression " +
+      "guard against a future syntactic-similarity tier reintroducing the same over-fire.",
     candidate: design({
       id: "candidate",
       touches: ["src/auth/login.ts"],
@@ -496,7 +512,7 @@ export const EVAL_CASES: EvalCase[] = [
         summary: "Refactor the billing module to improve error handling and add tests",
       }),
     ],
-    expectedVerdict: "overlap",
+    expectedVerdict: "clean",
     futureLlmExpectation: "should_stay_clean",
   },
 
@@ -539,7 +555,7 @@ export const EVAL_CASES: EvalCase[] = [
         summary: "Add a FeatureFlagClient helper that wraps the flag-check API with caching, wired into checkout to gate the new payment method.",
       }),
     ],
-    expectedVerdict: "overlap",
+    expectedVerdict: "file_overlap",
     expectedOverlapKind: "creates",
     futureLlmExpectation: "should_flag_as_conflict",
     otherPlanModeProvenance: {
@@ -723,16 +739,26 @@ export const EVAL_CASES: EvalCase[] = [
   },
 
   // ---------------------------------------------------------------------
-  // constraint coverage -- case 4 only ever exercised review_required;
-  // canonical_abstraction/domain_fact never appeared, and neither did the
-  // priority/specificity tiebreak logic CONSTRAINT_TYPE_PRIORITY implements.
+  // constraint coverage -- case 4 only ever exercised one constraint's
+  // scope/statement shape. 2026-08-26: `DesignConstraintType` collapsed to
+  // a single value (`review_required`/`canonical_abstraction`/`domain_fact`
+  // were mechanically identical -- see DesignVerdict's doc comment,
+  // core/types.ts), and `CONSTRAINT_TYPE_PRIORITY`'s tiebreak logic was
+  // removed with it -- several matching constraints now sort by
+  // scope-specificity alone. Cases 16/17 predate that collapse (originally
+  // written to cover the two other type values) and are kept as scope/
+  // statement-shape variety coverage now that the type distinction is gone;
+  // 18/19 predate the priority removal and are kept as pure specificity-
+  // tiebreak coverage -- both still pass unchanged since the narrower/
+  // longer scope in each already happened to be the one the old priority
+  // rule picked too.
   // ---------------------------------------------------------------------
   {
     id: "obvious-16-constraint-canonical-abstraction",
     bucket: "obvious_conflict",
     category: "constraint_match",
     source: "manual",
-    rationale: "canonical_abstraction has never appeared in this eval -- case 4 only ever exercised review_required.",
+    rationale: "Constraint-match coverage with a distinct scope/statement shape from case 4.",
     candidate: design({
       id: "candidate",
       touches: ["src/net/http-client-v2.ts"],
@@ -742,13 +768,13 @@ export const EVAL_CASES: EvalCase[] = [
     constraints: [
       constraint({
         id: "constraint-canonical",
-        type: "canonical_abstraction",
+        type: "constraint",
         statement: "use the shared HTTP client wrapper in src/net/http-client.ts; don't build a second one",
         scope: ["src/net/**"],
       }),
     ],
-    expectedVerdict: "constraint_flag",
-    expectedConstraintType: "canonical_abstraction",
+    expectedVerdict: "constraint_violation",
+    expectedConstraintType: "constraint",
     futureLlmExpectation: "should_flag_as_conflict",
   },
   {
@@ -756,7 +782,7 @@ export const EVAL_CASES: EvalCase[] = [
     bucket: "obvious_conflict",
     category: "constraint_match",
     source: "manual",
-    rationale: "domain_fact has never appeared in this eval either.",
+    rationale: "Constraint-match coverage with another distinct scope/statement shape.",
     candidate: design({
       id: "candidate",
       touches: ["src/payments/refund-calculator.ts"],
@@ -766,13 +792,13 @@ export const EVAL_CASES: EvalCase[] = [
     constraints: [
       constraint({
         id: "constraint-domain-fact",
-        type: "domain_fact",
+        type: "constraint",
         statement: "prices are stored in integer cents, never floating-point dollars, across the whole codebase",
         scope: ["src/billing/**", "src/payments/**"],
       }),
     ],
-    expectedVerdict: "constraint_flag",
-    expectedConstraintType: "domain_fact",
+    expectedVerdict: "constraint_violation",
+    expectedConstraintType: "constraint",
     futureLlmExpectation: "should_flag_as_conflict",
   },
   {
@@ -781,27 +807,29 @@ export const EVAL_CASES: EvalCase[] = [
     category: "constraint_match",
     source: "manual",
     rationale:
-      "Two constraints both match; the broader, lower-priority canonical_abstraction one is seeded FIRST in the " +
-      "array (mirrors the shape of a real production incident this repo's own constraint file was fixed for) -- " +
-      "proves review_required wins by priority, not by array order.",
+      "Two constraints both match; the broader one is seeded FIRST in the array (mirrors the shape of a real " +
+      "production incident this repo's own constraint file was fixed for) -- proves the narrower/more specific " +
+      "scope wins by specificity, not by array order. (Pre-2026-08-26 this case asserted a type-priority win; " +
+      "CONSTRAINT_TYPE_PRIORITY is gone, but the narrower scope here already happens to be the one that rule also " +
+      "picked, so the assertion is unchanged.)",
     candidate: design({ id: "candidate", touches: ["src/payments/refund.ts"], summary: "Add a refund endpoint" }),
     openDesigns: [design({ id: "open-unrelated", touches: ["src/ui/theme.css"], summary: "Adjust dark mode contrast ratios" })],
     constraints: [
       constraint({
         id: "constraint-broad",
-        type: "canonical_abstraction",
+        type: "constraint",
         statement: "use the shared validation helpers in src/validation/** everywhere",
         scope: ["src/**"],
       }),
       constraint({
         id: "constraint-narrow-review",
-        type: "review_required",
+        type: "constraint",
         statement: "src/payments/** requires payments-team sign-off for any change",
         scope: ["src/payments/**"],
       }),
     ],
-    expectedVerdict: "constraint_flag",
-    expectedConstraintType: "review_required",
+    expectedVerdict: "constraint_violation",
+    expectedConstraintType: "constraint",
     expectedConstraintStatement: "src/payments/** requires payments-team sign-off for any change",
     futureLlmExpectation: "should_flag_as_conflict",
   },
@@ -810,25 +838,25 @@ export const EVAL_CASES: EvalCase[] = [
     bucket: "obvious_conflict",
     category: "constraint_match",
     source: "manual",
-    rationale: "Two same-priority (canonical_abstraction) constraints both match; the more specific/longer scope glob must win.",
+    rationale: "Two constraints both match; the more specific/longer scope glob must win.",
     candidate: design({ id: "candidate", touches: ["src/billing/invoice-renderer.ts"], summary: "Render invoice PDFs with a new layout" }),
     openDesigns: [design({ id: "open-unrelated", touches: ["src/ui/theme.css"], summary: "Adjust dark mode contrast ratios" })],
     constraints: [
       constraint({
         id: "constraint-wide",
-        type: "canonical_abstraction",
+        type: "constraint",
         statement: "general rule: avoid duplicating date-formatting logic, use src/utils/date.ts",
         scope: ["src/**"],
       }),
       constraint({
         id: "constraint-specific",
-        type: "canonical_abstraction",
+        type: "constraint",
         statement: "invoice PDFs must use the invoice-specific date formatter in src/billing/invoice-date.ts, not the general one",
         scope: ["src/billing/invoice-*.ts"],
       }),
     ],
-    expectedVerdict: "constraint_flag",
-    expectedConstraintType: "canonical_abstraction",
+    expectedVerdict: "constraint_violation",
+    expectedConstraintType: "constraint",
     expectedConstraintStatement: "invoice PDFs must use the invoice-specific date formatter in src/billing/invoice-date.ts, not the general one",
     futureLlmExpectation: "should_flag_as_conflict",
   },
@@ -860,7 +888,7 @@ export const EVAL_CASES: EvalCase[] = [
       design({ id: "open-tier2", developerId: "dev2", creates: ["Bar"], touches: ["src/unrelated-y.ts"], summary: "Builds Bar, which the candidate assumes exists" }),
       design({ id: "open-unrelated", developerId: "dev2", creates: ["Zzz"], touches: ["src/z.ts"], summary: "Genuinely unrelated third design" }),
     ],
-    expectedVerdict: "overlap",
+    expectedVerdict: "file_overlap",
     expectedConflictCount: 1,
     futureLlmExpectation: "should_flag_as_conflict",
   },
@@ -877,7 +905,7 @@ export const EVAL_CASES: EvalCase[] = [
       design({ id: "open-p", developerId: "dev2", creates: ["Alpha"], summary: "Also builds Alpha" }),
       design({ id: "open-q", developerId: "dev2", creates: ["Beta"], summary: "Also builds Beta" }),
     ],
-    expectedVerdict: "overlap",
+    expectedVerdict: "file_overlap",
     expectedConflictCount: 2,
     futureLlmExpectation: "should_flag_as_conflict",
   },

--- a/packages/server/src/design-store.test.ts
+++ b/packages/server/src/design-store.test.ts
@@ -171,11 +171,11 @@ test("DesignRegistry: flag demotes an open design to flagged and logs the verdic
   const log = new DrizzleActivityLog(db);
   const registry = new DesignRegistry(db);
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "retry helper", creates: [], touches: [], dependsOn: [] });
-  const flagged = registry.flag(a.id, "overlap");
+  const flagged = registry.flag(a.id, "file_overlap");
   assert.equal(flagged?.status, "flagged");
   const events = log.eventsForRelatedId(a.id).filter((e) => e.kind === "design_flagged");
   assert.equal(events.length, 1);
-  assert.deepEqual(events[0].payload, { verdict: "overlap", summary: "retry helper" });
+  assert.deepEqual(events[0].payload, { verdict: "file_overlap", summary: "retry helper" });
   registry.stop();
 });
 
@@ -186,9 +186,9 @@ test("DesignRegistry: flag's optional detail persists the full conflicts/constra
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "retry helper", creates: [], touches: [], dependsOn: [] });
 
   const conflicts = [{ conflictingDesignId: "other-id", overlapKind: "touches" as const, overlapDetail: "both touch a.ts", conflictingSummary: "other design", overlapPaths: ["a.ts"] }];
-  registry.flag(a.id, "overlap", { conflicts });
+  registry.flag(a.id, "file_overlap", { conflicts });
   const events = log.eventsForRelatedId(a.id).filter((e) => e.kind === "design_flagged");
-  assert.deepEqual(events[0].payload, { verdict: "overlap", summary: "retry helper", conflicts });
+  assert.deepEqual(events[0].payload, { verdict: "file_overlap", summary: "retry helper", conflicts });
   registry.stop();
 });
 
@@ -198,10 +198,10 @@ test("DesignRegistry: flag's optional detail persists a constraint match, and om
   const registry = new DesignRegistry(db);
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "retry helper", creates: [], touches: [], dependsOn: [] });
 
-  const constraint = { id: "c1", statement: "use pkg/retry", type: "canonical_abstraction" as const };
-  registry.flag(a.id, "constraint_flag", { conflicts: [], constraints: [constraint] });
+  const constraint = { id: "c1", statement: "use pkg/retry", type: "constraint" as const };
+  registry.flag(a.id, "constraint_violation", { conflicts: [], constraints: [constraint] });
   const events = log.eventsForRelatedId(a.id).filter((e) => e.kind === "design_flagged");
-  assert.deepEqual(events[0].payload, { verdict: "constraint_flag", summary: "retry helper", constraints: [constraint] });
+  assert.deepEqual(events[0].payload, { verdict: "constraint_violation", summary: "retry helper", constraints: [constraint] });
   registry.stop();
 });
 
@@ -209,7 +209,7 @@ test("DesignRegistry: flag is a no-op on a design that isn't open", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [] });
   registry.close(a.id);
-  const result = registry.flag(a.id, "overlap");
+  const result = registry.flag(a.id, "file_overlap");
   assert.equal(result?.status, "closed"); // unchanged, not clobbered to "flagged"
   registry.stop();
 });
@@ -217,7 +217,7 @@ test("DesignRegistry: flag is a no-op on a design that isn't open", () => {
 test("DesignRegistry: openDesigns includes flagged designs, not just open ones", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [] });
-  registry.flag(a.id, "overlap");
+  registry.flag(a.id, "file_overlap");
   const b = registry.register({ projectId: "p1", developerId: "d2", sessionId: "s2", summary: "", creates: [], touches: [], dependsOn: [] });
   registry.close(b.id);
 
@@ -247,7 +247,7 @@ test("DesignRegistry: amend merges scope, bumps scopeVersion, and logs the delta
 test("DesignRegistry: amend refuses a design that isn't open", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [] });
-  registry.flag(a.id, "overlap");
+  registry.flag(a.id, "file_overlap");
   const result = registry.amend(a.id, { touches: ["b.ts"] });
   assert.equal(result, undefined);
   assert.deepEqual(registry.get(a.id)?.touches, []); // untouched
@@ -257,7 +257,7 @@ test("DesignRegistry: amend refuses a design that isn't open", () => {
 test("DesignRegistry: close also closes a flagged design, not just an open one", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [] });
-  registry.flag(a.id, "overlap");
+  registry.flag(a.id, "file_overlap");
   const closed = registry.close(a.id);
   assert.equal(closed?.status, "closed");
   assert.ok(closed?.closedAt);
@@ -267,7 +267,7 @@ test("DesignRegistry: close also closes a flagged design, not just an open one",
 test("DesignRegistry: closeSession also closes flagged designs for the session", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [] });
-  registry.flag(a.id, "overlap");
+  registry.flag(a.id, "file_overlap");
   const count = registry.closeSession("s1");
   assert.equal(count, 1);
   assert.equal(registry.get(a.id)?.status, "closed");
@@ -330,7 +330,7 @@ test("DesignRegistry: sweepExpired demotes an inactive open design to dormant, n
 test("DesignRegistry: sweepExpired also demotes an inactive flagged design to dormant", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [], ttlMs: 10 });
-  registry.flag(a.id, "overlap");
+  registry.flag(a.id, "file_overlap");
   registry.sweepExpired(a.createdAt + 1000);
   assert.equal(registry.get(a.id)?.status, "dormant");
   registry.stop();
@@ -441,7 +441,7 @@ test("DesignRegistry: openPlanModeDesignForSession ignores a different session o
 test("DesignRegistry: openPlanModeDesignForSession finds a flagged candidate too, not just open", () => {
   const registry = freshRegistry();
   const a = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "", creates: [], touches: [], dependsOn: [], rawPlanExcerpt: "text" });
-  registry.flag(a.id, "overlap");
+  registry.flag(a.id, "file_overlap");
   const found = registry.openPlanModeDesignForSession("p1", "s1");
   assert.equal(found?.id, a.id);
   assert.equal(found?.status, "flagged");
@@ -481,7 +481,7 @@ test("DesignRegistry: reregisterFromPlan fully replaces scope, bumps scopeVersio
     dependsOn: [],
     rawPlanExcerpt: "old plan text",
   });
-  registry.flag(a.id, "overlap"); // a candidate the caller found via openPlanModeDesignForSession may be flagged
+  registry.flag(a.id, "file_overlap"); // a candidate the caller found via openPlanModeDesignForSession may be flagged
 
   const reregistered = registry.reregisterFromPlan(a.id, {
     summary: "new summary",
@@ -779,39 +779,41 @@ test("DesignRegistry: close's sibling fan-out logs a design_closed event with pr
 test("ConstraintStore: add is idempotent per (projectId, statement) and persists across instances", () => {
   const dataDir = tmpDataDir();
   const store1 = new ConstraintStore(createDb({ dataDir }));
-  const c1 = store1.add("p1", "use pkg/retry", ["src/**"], "canonical_abstraction", "seeded");
-  const c2 = store1.add("p1", "use pkg/retry", ["src/**"], "canonical_abstraction", "seeded");
+  const c1 = store1.add("p1", "use pkg/retry", ["src/**"], "constraint", "seeded");
+  const c2 = store1.add("p1", "use pkg/retry", ["src/**"], "constraint", "seeded");
   assert.equal(c1.id, c2.id);
 
   const store2 = new ConstraintStore(createDb({ dataDir }));
   assert.equal(store2.forProject("p1").length, 1);
 });
 
-test("ConstraintStore: add updates scope/type on an existing statement match instead of ignoring the change (2026-08-16 fix)", () => {
+// 2026-08-26: this test used to also cover a "type change on an existing
+// statement match" sub-case (`add`'s scope/type-update fix, 2026-08-16) --
+// dropped, not just renamed, since `DesignConstraintType` collapsed to a
+// single value ("constraint") the same day, so there's no second value left
+// to change *to*. The scope-update half of that same fix is still real
+// behavior and still covered below.
+test("ConstraintStore: add updates scope on an existing statement match instead of ignoring the change (2026-08-16 fix)", () => {
   const store = new ConstraintStore(createDb({ dataDir: tmpDataDir() }));
-  const original = store.add("p1", "use pkg/retry", ["packages/**"], "canonical_abstraction", "seeded");
+  const original = store.add("p1", "use pkg/retry", ["packages/**"], "constraint", "seeded");
 
   // Re-seeding the same statement with a narrower scope -- before the fix,
   // this silently returned the stale packages/** row unchanged.
-  const narrowed = store.add("p1", "use pkg/retry", ["packages/core/src/retry.ts"], "canonical_abstraction", "seeded");
+  const narrowed = store.add("p1", "use pkg/retry", ["packages/core/src/retry.ts"], "constraint", "seeded");
   assert.equal(narrowed.id, original.id, "same constraint identity, not a duplicate row");
   assert.deepEqual(narrowed.scope, ["packages/core/src/retry.ts"]);
   assert.equal(store.forProject("p1").length, 1, "still exactly one row, updated in place");
 
-  // A type change on the same statement also applies.
-  const retyped = store.add("p1", "use pkg/retry", ["packages/core/src/retry.ts"], "review_required", "seeded");
-  assert.equal(retyped.type, "review_required");
-
   // A no-op re-seed (identical scope and type) doesn't append a redundant update.
-  const unchanged = store.add("p1", "use pkg/retry", ["packages/core/src/retry.ts"], "review_required", "seeded");
-  assert.equal(unchanged.id, retyped.id);
+  const unchanged = store.add("p1", "use pkg/retry", ["packages/core/src/retry.ts"], "constraint", "seeded");
+  assert.equal(unchanged.id, narrowed.id);
 });
 
 test("ConstraintStore: get finds by id, remove deletes and logs constraint_removed, both are no-ops on an unknown id", () => {
   const dataDir = tmpDataDir();
   const activityLog = new DrizzleActivityLog(createDb({ dataDir }));
   const store = new ConstraintStore(createDb({ dataDir }), { activityLog });
-  const created = store.add("p1", "use pkg/retry", ["src/**"], "canonical_abstraction", "seeded");
+  const created = store.add("p1", "use pkg/retry", ["src/**"], "constraint", "seeded");
 
   assert.deepEqual(store.get(created.id), created);
   assert.equal(store.get("no-such-id"), undefined);

--- a/packages/server/src/design-store.ts
+++ b/packages/server/src/design-store.ts
@@ -41,6 +41,7 @@ export type NewDesignInput = Omit<
   | "justifiedConstraintIds"
   | "justifiedOverlaps"
   | "justifiedConflicts"
+  | "justifiedSymbolConflicts"
 > & {
   ttlMs?: number;
 };
@@ -67,6 +68,7 @@ interface DesignRow {
   justifiedConstraintIds: string;
   justifiedOverlaps: string;
   justifiedConflicts: string;
+  justifiedSymbolConflicts: string;
 }
 
 function fromDesignRow(row: DesignRow): DesignStatement {
@@ -92,6 +94,7 @@ function fromDesignRow(row: DesignRow): DesignStatement {
     justifiedConstraintIds: JSON.parse(row.justifiedConstraintIds),
     justifiedOverlaps: JSON.parse(row.justifiedOverlaps),
     justifiedConflicts: JSON.parse(row.justifiedConflicts),
+    justifiedSymbolConflicts: JSON.parse(row.justifiedSymbolConflicts),
   };
 }
 
@@ -105,12 +108,14 @@ interface ReviewRow {
   constraintIds: string;
   overlapWaivers: string;
   conflictWaivers: string;
+  symbolConflictWaivers: string;
 }
 
 function fromReviewRow(row: ReviewRow): PendingReview {
   const constraintIds = JSON.parse(row.constraintIds) as string[];
   const overlapWaivers = JSON.parse(row.overlapWaivers) as { conflictingDesignId: string; paths: string[] }[];
   const conflictWaivers = JSON.parse(row.conflictWaivers) as { conflictingDesignId: string }[];
+  const symbolConflictWaivers = JSON.parse(row.symbolConflictWaivers) as { conflictingDesignId: string; symbolIds: string[] }[];
   return {
     id: row.id,
     designId: row.designId,
@@ -121,6 +126,7 @@ function fromReviewRow(row: ReviewRow): PendingReview {
     constraintIds: constraintIds.length > 0 ? constraintIds : undefined,
     overlapWaivers: overlapWaivers.length > 0 ? overlapWaivers : undefined,
     conflictWaivers: conflictWaivers.length > 0 ? conflictWaivers : undefined,
+    symbolConflictWaivers: symbolConflictWaivers.length > 0 ? symbolConflictWaivers : undefined,
   };
 }
 
@@ -162,6 +168,7 @@ export class DesignRegistry {
       justifiedConstraintIds: [],
       justifiedOverlaps: [],
       justifiedConflicts: [],
+      justifiedSymbolConflicts: [],
     };
     this.db
       .insert(designsTable)
@@ -187,6 +194,7 @@ export class DesignRegistry {
         justifiedConstraintIds: JSON.stringify([] as string[]),
         justifiedOverlaps: JSON.stringify([] as string[]),
         justifiedConflicts: JSON.stringify([] as string[]),
+        justifiedSymbolConflicts: JSON.stringify([] as string[]),
       })
       .run();
     this.activityLog.append({
@@ -745,6 +753,7 @@ export class DesignRegistry {
     constraintIds?: string[],
     overlapWaivers?: { conflictingDesignId: string; paths: string[] }[],
     conflictWaivers?: { conflictingDesignId: string }[],
+    symbolConflictWaivers?: { conflictingDesignId: string; symbolIds: string[] }[],
   ): PendingReview {
     const review: PendingReview = {
       id: crypto.randomUUID(),
@@ -755,6 +764,7 @@ export class DesignRegistry {
       constraintIds,
       overlapWaivers,
       conflictWaivers,
+      symbolConflictWaivers,
     };
     this.db
       .insert(reviewsTable)
@@ -768,6 +778,7 @@ export class DesignRegistry {
         constraintIds: JSON.stringify(constraintIds ?? []),
         overlapWaivers: JSON.stringify(overlapWaivers ?? []),
         conflictWaivers: JSON.stringify(conflictWaivers ?? []),
+        symbolConflictWaivers: JSON.stringify(symbolConflictWaivers ?? []),
       })
       .run();
     this.activityLog.append({
@@ -775,7 +786,7 @@ export class DesignRegistry {
       kind: "review_created",
       relatedId: review.id,
       ts: review.createdAt,
-      payload: { designId, justification, constraintIds, overlapWaivers, conflictWaivers },
+      payload: { designId, justification, constraintIds, overlapWaivers, conflictWaivers, symbolConflictWaivers },
     });
     return review;
   }
@@ -868,6 +879,19 @@ export class DesignRegistry {
       decision === "approve" && design && review.conflictWaivers && review.conflictWaivers.length > 0
         ? [...new Set([...design.justifiedConflicts, ...review.conflictWaivers.map((w) => w.conflictingDesignId)])]
         : undefined;
+    // "symbol_conflict"'s own approval memory (2026-08-26) -- same
+    // append-on-approve-only shape as justifiedOverlaps above, keyed by
+    // (conflictingDesignId, symbolId) via the same overlapWaiverKey helper.
+    // See DesignStatement.justifiedSymbolConflicts' own doc comment.
+    const justifiedSymbolConflicts =
+      decision === "approve" && design && review.symbolConflictWaivers && review.symbolConflictWaivers.length > 0
+        ? [
+            ...new Set([
+              ...design.justifiedSymbolConflicts,
+              ...review.symbolConflictWaivers.flatMap((w) => w.symbolIds.map((s) => overlapWaiverKey(w.conflictingDesignId, s))),
+            ]),
+          ]
+        : undefined;
     this.db
       .update(designsTable)
       .set({
@@ -876,6 +900,7 @@ export class DesignRegistry {
         ...(justifiedConstraintIds ? { justifiedConstraintIds: JSON.stringify(justifiedConstraintIds) } : {}),
         ...(justifiedOverlaps ? { justifiedOverlaps: JSON.stringify(justifiedOverlaps) } : {}),
         ...(justifiedConflicts ? { justifiedConflicts: JSON.stringify(justifiedConflicts) } : {}),
+        ...(justifiedSymbolConflicts ? { justifiedSymbolConflicts: JSON.stringify(justifiedSymbolConflicts) } : {}),
       })
       .where(eq(designsTable.id, review.designId))
       .run();

--- a/packages/server/src/review-enrich.ts
+++ b/packages/server/src/review-enrich.ts
@@ -33,10 +33,15 @@ import type {
 export type DesignLookup = (id: string) => DesignStatement | undefined;
 export type ConstraintLookup = (id: string) => DesignConstraint | undefined;
 
-/** `overlapWaivers` and `conflictWaivers` answer the same human question --
- * "whose work does this collide with?" -- so they're merged into one list,
- * `kind` preserving which check produced each. Order is stable: overlaps
- * first, then semantic conflicts, each in the order recorded. */
+/** `overlapWaivers`, `conflictWaivers`, and (2026-08-26) `symbolConflictWaivers`
+ * all answer the same human question -- "whose work does this collide
+ * with?" -- so they're merged into one list, `kind` preserving which check
+ * produced each (`"overlap"`/`"conflict"` are this field's own waiver-kind
+ * labels, not `DesignVerdict` values -- `"conflict"` here means what's now
+ * called the `llm_divergence` bucket; left unrenamed to keep this field's
+ * diff bounded, see `ReviewConflictSummary`'s doc comment in core/types.ts).
+ * Order is stable: overlaps, then semantic conflicts, then symbol
+ * conflicts, each in the order recorded. */
 function collectConflicts(review: PendingReview, lookupDesign: DesignLookup): ReviewConflictSummary[] {
   const out: ReviewConflictSummary[] = [];
 
@@ -56,6 +61,16 @@ function collectConflicts(review: PendingReview, lookupDesign: DesignLookup): Re
       designId: waiver.conflictingDesignId,
       kind: "conflict",
       ...(other ? { summary: other.summary, developerId: other.developerId } : {}),
+    });
+  }
+
+  for (const waiver of review.symbolConflictWaivers ?? []) {
+    const other = lookupDesign(waiver.conflictingDesignId);
+    out.push({
+      designId: waiver.conflictingDesignId,
+      kind: "symbol_conflict",
+      ...(other ? { summary: other.summary, developerId: other.developerId } : {}),
+      ...(waiver.symbolIds.length > 0 ? { paths: waiver.symbolIds } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary
Replaces the five-verdict / severity / three-way-constraint-type / four-way-align-category sprawl with exactly four `DesignVerdict` buckets. One principle: **approval belongs to whoever's authority you'd be overriding.**

| # | Bucket | Between | Blocking? | Resolved by |
|---|---|---|---|---|
| 1 | `constraint_violation` | design vs. a fixed project rule | yes | admin approves |
| 2 | `file_overlap` | two designs' declared plans | no, advisory | nothing |
| 3 | `symbol_conflict` | two designs' actual edits | yes | self-approves |
| 4 | `llm_divergence` | two designs' stated intent (Bedrock) | yes | self-approves |

See the README's new "The four conflict buckets" section for the full table + sub-kinds.

## Key changes
- `DesignSeverity`/`severity` dropped entirely — blocking is now a pure function of verdict.
- `DesignConstraintType` collapsed to one literal, kept on the wire (no backfill of old rows).
- `symbol_conflict` is new: real-edit collisions (`checks.ts`/`design-divergence.ts`) now flag whichever side(s) have an open design, not just advisory.
- `POST /v1/designs/:id/resolve` self-approves instantly when a review carries zero constraint hits.
- `AlignmentCategory` collapsed to two values + a new `subKind` for the old detail label; `legacyCategoryBucket()` handles pre-2026-08-26 rows.
- `hook/design_gate.go` deny messages branch on a new `requiresAdmin` flag instead of the dropped constraint-type switch.
- Migration `0011`: three new additive/defaulted columns, applied automatically by the existing migrate-on-boot path — no backfill needed.

## Migration note for the live coordinator
This is purely additive at the schema level (new nullable/defaulted columns only) and applies automatically on next `docker compose up -d --build`. Historical `activity_events`/`alignment_threads`/`constraints.type` rows keep their old string values, read via fallback logic (`legacyCategoryBucket`, raw pass-through) rather than being rewritten, consistent with this repo's existing "insert-only, never rewritten" convention. **`monitor.twing.dev` (twing-monitor repo) needs its own matching deploy alongside this one**, or the live dashboard will read the new verdict/category names incorrectly (same class of break as the constraint-payload pluralization before it).

## Testing
`npm run build && npm run test` — 307/307 server, 34/34 cli, 112/112 core. `go build/vet/test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
