### PR TITLE
Fix scope-match: flagged designs must outrank dormant ones

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2381,6 +2381,120 @@ test("GET /v1/designs/scope-match: dormant state end-to-end, with summary and do
   assert.ok(typeof body.dormantSinceMs === "number" && body.dormantSinceMs >= 0);
 });
 
+// Found live (2026-08-26): dormant was checked before flagged, so a session
+// carrying any dormant design at all could never learn about a real,
+// possibly admin-gated, flagged/pending-review block sitting right next to
+// it -- it always got told to `design resume` the dormant one instead,
+// which silently reactivates unrelated stale work while hiding the actual
+// blocker. Flagged must now win.
+test("GET /v1/designs/scope-match: a flagged design takes priority over a dormant one in the same session", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  const dormantRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "old plan", creates: [], touches: ["a.ts"], dependsOn: [], ttlMs: 10 }),
+  });
+  const { designId: dormantId } = (await dormantRes.json()) as { designId: string };
+  designs.sweepExpired(Date.now() + 1000); // -> dormant
+
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected path", scope: ["protected.ts"], type: "constraint" }] }),
+  });
+  const flaggedRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "new plan", creates: [], touches: ["protected.ts"], dependsOn: [], force: true }),
+  });
+  const { designId: flaggedId, verdict } = (await flaggedRes.json()) as { designId: string; verdict: string };
+  assert.equal(verdict, "constraint_violation");
+
+  // Before the fix, this returned "dormant" and never mentioned the
+  // constraint-violation block right next to it.
+  const scopeMatch = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=z.ts`, { headers: bearer(admin.token) });
+  const body = (await scopeMatch.json()) as { state: string; designId?: string; requiresAdmin?: boolean };
+  assert.equal(body.state, "flagged");
+  assert.equal(body.designId, flaggedId);
+  assert.notEqual(body.designId, dormantId);
+  assert.equal(body.requiresAdmin, true);
+});
+
+// The block is session-wide regardless of which flagged design gets named,
+// but the named design should still be the one actually relevant to `path`
+// when more than one is flagged -- same "prefer a scope match, only then
+// fall back to newest" shape as the out_of_scope/dormant picks.
+test("GET /v1/designs/scope-match: with more than one flagged design, the one whose scope covers path is named, not just the newest", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({
+      projectId: "proj-1",
+      constraints: [
+        { statement: "protected path A", scope: ["a-protected.ts"], type: "constraint" },
+        { statement: "protected path B", scope: ["b-protected.ts"], type: "constraint" },
+      ],
+    }),
+  });
+
+  const olderRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "older", creates: [], touches: ["a-protected.ts"], dependsOn: [], force: true }),
+  });
+  const { designId: olderId } = (await olderRes.json()) as { designId: string };
+
+  const newerRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newer", creates: [], touches: ["b-protected.ts"], dependsOn: [], force: true }),
+  });
+  const { designId: newerId } = (await newerRes.json()) as { designId: string };
+
+  // Asking about the *older* design's file must still name the older
+  // design, even though the newer one would win a plain newest-first pick.
+  const scopeMatch = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=a-protected.ts`, { headers: bearer(admin.token) });
+  const body = (await scopeMatch.json()) as { state: string; designId?: string };
+  assert.equal(body.state, "flagged");
+  assert.equal(body.designId, olderId, "must name the flagged design whose scope actually covers path, not just the newest");
+  assert.notEqual(body.designId, newerId);
+});
+
+// Same bug class as the out_of_scope newest-first fix above, applied to the
+// dormant fallback: `dormantOnes[dormantOnes.length - 1]` picked the oldest
+// dormant design, not the most recently parked one.
+test("GET /v1/designs/scope-match: dormant fallback picks the newest dormant design, not the oldest", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  const firstRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "oldest task", creates: [], touches: ["a.ts"], dependsOn: [], ttlMs: 10 }),
+  });
+  const { designId: firstId } = (await firstRes.json()) as { designId: string };
+
+  const secondRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newest task", creates: [], touches: ["b.ts"], dependsOn: [], ttlMs: 10, force: true }),
+  });
+  const { designId: secondId } = (await secondRes.json()) as { designId: string };
+
+  designs.sweepExpired(Date.now() + 1000); // both -> dormant
+
+  const scopeMatch = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=z.ts`, { headers: bearer(admin.token) });
+  const body = (await scopeMatch.json()) as { state: string; designId?: string };
+  assert.equal(body.state, "dormant");
+  assert.notEqual(body.designId, firstId);
+  assert.equal(body.designId, secondId, "must pick the newest dormant design, not the oldest");
+});
+
 test("GET /v1/designs/scope-match: a real in_scope hit bumps the design's lastActivityAt", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1414,12 +1414,21 @@ export function createApp(options: CreateAppOptions = {}) {
   //    gets recorded, since this call already round-trips synchronously on
   //    every real Edit/Write).
   //  - "out_of_scope": an open design exists but none cover `path`.
-  //  - "dormant" (§17 design lifecycle, 2026-08): no open design (matching
-  //    or not), but a dormant one exists -- never silently allowed or
-  //    woken; points at `twing design resume`, which re-checks against
-  //    whatever's live before reactivating anything.
   //  - "flagged": something's registered, but its own verdict wasn't clean
   //    (DesignRegistry.flag) -- resolve it before it counts as usable.
+  //    Checked *before* "dormant" (found live, 2026-08-26 -- see the fix
+  //    note below): a flagged design is an active block, possibly
+  //    admin-gated, on work this session actually registered; a dormant
+  //    design is just idle, parked work nobody's asked to resume. Ranking
+  //    "idle" above "actively blocked" meant a session carrying any dormant
+  //    design at all could never learn about a real flagged/pending-review
+  //    block sitting right next to it -- it always got told to `design
+  //    resume` the dormant one instead, which silently reactivates
+  //    unrelated stale work while hiding the actual blocker.
+  //  - "dormant" (§17 design lifecycle, 2026-08): no open or flagged design
+  //    (matching or not), but a dormant one exists -- never silently
+  //    allowed or woken; points at `twing design resume`, which re-checks
+  //    against whatever's live before reactivating anything.
   //  - "no_design": nothing registered for this session at all (or
   //    everything's closed/superseded/expired).
   app.get("/v1/designs/scope-match", (c) => {
@@ -1463,36 +1472,50 @@ export function createApp(options: CreateAppOptions = {}) {
       });
     }
 
-    const dormantOnes = sessionDesigns.filter((d) => d.status === "dormant");
-    if (dormantOnes.length > 0) {
-      const now = Date.now();
-      const named = (path && dormantOnes.find((d) => pathInDesignScope(path, d))) || dormantOnes[dormantOnes.length - 1];
-      return c.json({ state: "dormant", designId: named.id, summary: named.summary, dormantSinceMs: now - named.lastActivityAt });
+    // Checked before "dormant" -- see this endpoint's own doc comment above
+    // for why an active block outranks idle/parked work. pendingReview
+    // distinguishes "never resolved" from "resolved, an admin just hasn't
+    // decided yet" (found live, 2026-08-16) -- both used to render as the
+    // identical deny telling you to run `twing design resolve`, even right
+    // after you'd already done so.
+    const flaggedOnes = sessionDesigns.filter((d) => d.status === "flagged");
+    if (flaggedOnes.length > 0) {
+      // The block itself is session-wide, not scoped to `path` -- once no
+      // open design covers the file, any unresolved flagged design blocks
+      // regardless of what it declared. But which *one* gets named in the
+      // deny message is still worth getting right when there's more than
+      // one: same "prefer an actual scope match, only then fall back to
+      // newest" shape as `openOnes`/`dormantOnes` above (found live,
+      // 2026-08-26) -- naming the flagged design that's actually about
+      // `path` is a more actionable deny than always naming whichever was
+      // flagged most recently, which could be about an unrelated file.
+      const flaggedDesign = (path && flaggedOnes.find((d) => pathInDesignScope(path, d))) || flaggedOnes[0];
+      // requiresAdmin (2026-08-26): which of the two self-approvable buckets
+      // vs. the one admin-gated bucket actually flagged this design --
+      // `designs.flag()` doesn't stamp `verdict` onto the design row itself
+      // (it's a `status` transition, not a field), so the only record of it
+      // is the `design_flagged` activity event's own payload. Read back the
+      // most recent one (a design can be flagged more than once across its
+      // lifetime -- amend, a later semantic-comparator pass, etc.) rather
+      // than the first, since only the *current* flag is what's actually
+      // blocking right now. Lets the Go hook's deny message tell "justify it
+      // and you're unblocked immediately" apart from "this goes to a project
+      // admin" instead of always saying the latter -- see DesignVerdict's doc
+      // comment (core/types.ts) for the full four-bucket model.
+      const flagEvents = activityLog.eventsForRelatedId(flaggedDesign.id).filter((e) => e.kind === "design_flagged");
+      const latestFlagVerdict = flagEvents.length > 0 ? (flagEvents[flagEvents.length - 1].payload as { verdict?: string } | undefined)?.verdict : undefined;
+      const requiresAdmin = latestFlagVerdict === "constraint_violation";
+      return c.json({ state: "flagged", designId: flaggedDesign.id, pendingReview: designs.hasPendingReview(flaggedDesign.id), requiresAdmin });
     }
 
-    // Only flagged designs remain, since sessionDesigns was non-empty and
-    // openOnes/dormantOnes were both empty. pendingReview distinguishes
-    // "never resolved" from "resolved, an admin just hasn't decided yet"
-    // (found live, 2026-08-16) -- both used to render as the identical
-    // deny telling you to run `twing design resolve`, even right after
-    // you'd already done so.
-    const flaggedDesign = sessionDesigns[sessionDesigns.length - 1];
-    // requiresAdmin (2026-08-26): which of the two self-approvable buckets
-    // vs. the one admin-gated bucket actually flagged this design --
-    // `designs.flag()` doesn't stamp `verdict` onto the design row itself
-    // (it's a `status` transition, not a field), so the only record of it
-    // is the `design_flagged` activity event's own payload. Read back the
-    // most recent one (a design can be flagged more than once across its
-    // lifetime -- amend, a later semantic-comparator pass, etc.) rather
-    // than the first, since only the *current* flag is what's actually
-    // blocking right now. Lets the Go hook's deny message tell "justify it
-    // and you're unblocked immediately" apart from "this goes to a project
-    // admin" instead of always saying the latter -- see DesignVerdict's doc
-    // comment (core/types.ts) for the full four-bucket model.
-    const flagEvents = activityLog.eventsForRelatedId(flaggedDesign.id).filter((e) => e.kind === "design_flagged");
-    const latestFlagVerdict = flagEvents.length > 0 ? (flagEvents[flagEvents.length - 1].payload as { verdict?: string } | undefined)?.verdict : undefined;
-    const requiresAdmin = latestFlagVerdict === "constraint_violation";
-    return c.json({ state: "flagged", designId: flaggedDesign.id, pendingReview: designs.hasPendingReview(flaggedDesign.id), requiresAdmin });
+    // Only dormant designs remain, since sessionDesigns was non-empty and
+    // openOnes/flaggedOnes were both empty.
+    const dormantOnes = sessionDesigns.filter((d) => d.status === "dormant");
+    const now = Date.now();
+    // Same newest-first pick as above -- `dormantOnes[0]`, not
+    // `[dormantOnes.length - 1]` (found live, 2026-08-26, same bug class).
+    const named = (path && dormantOnes.find((d) => pathInDesignScope(path, d))) || dormantOnes[0];
+    return c.json({ state: "dormant", designId: named.id, summary: named.summary, dormantSinceMs: now - named.lastActivityAt });
   });
 
   // §17.5: the human-facing queue -- justified divergences pending sign-off.


### PR DESCRIPTION
## Summary
Fixes a serious bug in `GET /v1/designs/scope-match`: dormant designs were checked before flagged ones, so a session carrying any dormant design could never learn about an active flagged/pending-review block (including admin-gated `constraint_violation`) sitting right next to it. The gate's own suggested `design resume` command would silently reactivate unrelated stale work while hiding the real blocker.

## Fixes
- Reorder: `flagged` is now checked before `dormant`.
- Both the dormant and flagged fallback picks grabbed the *oldest* candidate (`[length - 1]`) instead of the newest (`[0]`) -- same bug class as the already-fixed `out_of_scope` pick.
- Flagged's pick now also prefers a design whose scope actually covers `path` before falling back to newest, matching how `open`/`dormant` already choose.

## Testing
Three new regression tests added to `app.test.ts`. Full workspace green: 310 server / 112 CLI / 34 core tests, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
