### PR TITLE
Alignment threads: show when a block was actually resolved

### DIFF
--- a/packages/server/src/alignment-store.test.ts
+++ b/packages/server/src/alignment-store.test.ts
@@ -80,6 +80,82 @@ test("AlignmentThreadStore: initiatingDesignId is set once resolved and never cl
   assert.equal(second.initiatingDesignId, "alice-design-1", "must not regress from known to unknown");
 });
 
+// Found live (2026-08-26): llm_divergence's one-directional detection
+// (runSemanticComparatorPass only ever checks the *current* design being
+// registered/amended against everything else open) meant the reverse
+// direction -- the other developer's own later registration getting
+// checked against *this* design -- never recognized it as the same
+// underlying tension, and forked a second thread for what was one
+// disagreement between one pair of designs.
+test("AlignmentThreadStore: findOrCreate reuses the same llm_divergence thread when the reverse direction reports the same design pair", () => {
+  const { store } = freshStore();
+  const semanticInput = {
+    ...baseInput,
+    category: "llm_divergence" as const,
+    subKind: "tension" as const,
+    symbolIds: [],
+    designId: "bobs-design", // the *other* design, from alice's point of view
+    initiatingDesignId: "alices-design", // alice's own design, the one flagged here
+    systemDescription: "alice's registration found tension with bob's open design",
+  };
+  const first = store.findOrCreate(semanticInput);
+  assert.equal(first.initiatingDesignId, "alices-design");
+  assert.equal(first.designId, "bobs-design");
+
+  // Bob's own registration later triggers its own one-directional check
+  // against alice's design -- developerId/otherDeveloperId reversed, and
+  // designId/initiatingDesignId swapped to match (bob's designId is now
+  // "the other design", alice's; bob's initiatingDesignId is his own).
+  const reverseInput = {
+    ...semanticInput,
+    developerId: "bob",
+    otherDeveloperId: "alice",
+    designId: "alices-design",
+    initiatingDesignId: "bobs-design",
+    systemDescription: "bob's registration found the same tension with alice's design",
+  };
+  const second = store.findOrCreate(reverseInput);
+
+  assert.equal(second.id, first.id, "must reuse the one existing thread, not fork a second one for the reverse direction");
+  assert.equal(second.initiatingDesignId, "alices-design", "must not regress the already-known initiator");
+  assert.equal(second.designId, "bobs-design", "designId is set at creation and never touched by amend");
+
+  const messages = store.messages(first.id);
+  assert.equal(messages.length, 2, "bob's own finding is still worth a follow-up message in the shared thread");
+  assert.equal(messages[1].message, "bob's registration found the same tension with alice's design");
+});
+
+// A genuinely different pair (or a pair that doesn't fully match on both
+// design ids) must not accidentally merge into someone else's thread --
+// the reverse match requires *both* initiatingDesignId and designId to
+// line up, not just the developer pair.
+test("AlignmentThreadStore: the reverse-direction match requires both design ids to line up, not just the developer pair", () => {
+  const { store } = freshStore();
+  const semanticInput = {
+    ...baseInput,
+    category: "llm_divergence" as const,
+    subKind: "tension" as const,
+    symbolIds: [],
+    designId: "bobs-design",
+    initiatingDesignId: "alices-design",
+  };
+  const first = store.findOrCreate(semanticInput);
+
+  // Same developer pair (reversed), but bob's own design here is a
+  // *different* one than the thread already knows about -- a genuinely
+  // separate, unrelated tension between the same two people.
+  const unrelated = store.findOrCreate({
+    ...semanticInput,
+    developerId: "bob",
+    otherDeveloperId: "alice",
+    designId: "alices-design",
+    initiatingDesignId: "bobs-other-design",
+    systemDescription: "an unrelated tension",
+  });
+
+  assert.notEqual(unrelated.id, first.id, "must not merge into a thread about a different design of bob's");
+});
+
 test("AlignmentThreadStore: findOrCreate opens a new thread once the prior one is closed", () => {
   const { store } = freshStore();
   const first = store.findOrCreate(baseInput);
@@ -118,6 +194,22 @@ test("AlignmentThreadStore: postMessage appends to the thread's message history 
   assert.equal(messages[1].authorId, "bob");
   assert.equal(messages[1].message, "ack, I'll rename mine");
   assert.equal(messages[2].authorId, "alice");
+});
+
+test("AlignmentThreadStore: postSystemMessage requires an existing thread", () => {
+  const { store } = freshStore();
+  assert.equal(store.postSystemMessage("no-such-thread", "resolved"), undefined);
+});
+
+test("AlignmentThreadStore: postSystemMessage appends an author-less message, same as the auto-generated seed note", () => {
+  const { store } = freshStore();
+  const thread = store.findOrCreate(baseInput);
+  store.postSystemMessage(thread.id, "Resolved: alice's design was approved");
+
+  const messages = store.messages(thread.id);
+  assert.equal(messages.length, 2);
+  assert.equal(messages[1].message, "Resolved: alice's design was approved");
+  assert.equal(messages[1].authorId, undefined, "a system note has no author, same as the seed message");
 });
 
 test("AlignmentThreadStore: close is idempotent -- closing twice doesn't double-log", () => {

--- a/packages/server/src/alignment-store.ts
+++ b/packages/server/src/alignment-store.ts
@@ -21,7 +21,7 @@
  */
 
 import * as crypto from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import type { Db } from "./db/client.js";
 import { alignmentThreads as threadsTable } from "./db/schema.js";
 import { DrizzleActivityLog } from "./activity-log.js";
@@ -226,19 +226,58 @@ export class AlignmentThreadStore {
    * instead -- merging new `symbolIds` in, bumping `lastActivityAt`, and
    * posting a follow-up message only when something genuinely new is being
    * recorded -- is the actual fix; see this file's header comment on why a
-   * follow-up message rather than a silent mutation. */
+   * follow-up message rather than a silent mutation.
+   *
+   * 2026-08-26: same bug class, different axis -- direction. `checks.ts`'s
+   * `recordSymbolConflict` resolves and flags *both* sides in one call, so
+   * `symbol_conflict` naturally gets one shared thread. `llm_divergence`
+   * doesn't: `runSemanticComparatorPass` only ever checks the *current*
+   * design being registered/amended against everything else already open --
+   * one-directional by construction. When A registers and gets checked
+   * against B's open design, then B later registers/amends and gets
+   * checked against A's, those are two separate calls with
+   * `developerId`/`otherDeveloperId` in opposite order (A,B) vs (B,A) -- the
+   * forward-only dedup above never recognized them as the same underlying
+   * tension between the same two designs, so it forked a second thread
+   * (confirmed live: two separate threads for what was one disagreement
+   * between one pair of designs). Fixed by also matching the *reverse*
+   * shape: a reverse call's `otherDeveloperId`/`developerId` swap the
+   * existing row's `developerId`/`otherDeveloperId`, and its `designId`
+   * (the *other* side's design, from the new caller's point of view) is the
+   * existing row's `initiatingDesignId` (the side that got flagged
+   * *first*) -- and symmetrically, the reverse call's own
+   * `initiatingDesignId` is the existing row's `designId`. Both design-id
+   * links are required together (not just one) so this can't accidentally
+   * merge two genuinely-different conflicts that happen to share only one
+   * side; either id being unresolved (as `checkAmendedScope`'s callers
+   * sometimes are) just skips the reverse match, same forward-only
+   * fallback as before this fix. */
   findOrCreate(input: FindOrCreateInput): AlignmentThread {
-    const dedupConditions = [
+    const forward = [
       eq(threadsTable.projectId, input.projectId),
       eq(threadsTable.developerId, input.developerId),
       eq(threadsTable.otherDeveloperId, input.otherDeveloperId),
       eq(threadsTable.status, "open"),
     ];
-    if (input.designId) dedupConditions.push(eq(threadsTable.designId, input.designId));
+    if (input.designId) forward.push(eq(threadsTable.designId, input.designId));
+
+    const conditions = [and(...forward)!];
+    if (input.designId && input.initiatingDesignId) {
+      conditions.push(
+        and(
+          eq(threadsTable.projectId, input.projectId),
+          eq(threadsTable.developerId, input.otherDeveloperId),
+          eq(threadsTable.otherDeveloperId, input.developerId),
+          eq(threadsTable.status, "open"),
+          eq(threadsTable.initiatingDesignId, input.designId),
+          eq(threadsTable.designId, input.initiatingDesignId),
+        )!,
+      );
+    }
     const existingRow = this.db
       .select()
       .from(threadsTable)
-      .where(and(...dedupConditions))
+      .where(or(...conditions))
       .get() as ThreadRow | undefined;
     if (existingRow) return this.amend(existingRow, input);
 
@@ -380,6 +419,32 @@ export class AlignmentThreadStore {
       payload: { message },
     });
     return { authorId, message, ts };
+  }
+
+  /** Same shape as `postMessage`, author-less -- for a note the coordinator
+   * itself is making, not a party replying (2026-08-26). `messages()` reads
+   * these back the same way it already does the auto-generated seed note in
+   * `findOrCreate` (also author-less, same `alignment_message_posted` kind);
+   * `AlignmentMessage.authorId` has been optional for exactly this since
+   * that seed note existed, this just gives a second, later-in-the-thread's-
+   * life caller the same capability. See `app.ts`'s
+   * `notifyAlignmentThreadsOfDecision` for the one caller: resolving a
+   * design's block (self-approve or admin-decide) never touched its paired
+   * thread at all, so a genuinely-resolved conflict and one nobody ever
+   * came back to looked identical from here -- both just sat "open"
+   * forever. */
+  postSystemMessage(threadId: string, message: string): AlignmentMessage | undefined {
+    const thread = this.get(threadId);
+    if (!thread) return undefined;
+    const ts = Date.now();
+    this.activityLog.append({
+      projectId: thread.projectId,
+      kind: "alignment_message_posted",
+      relatedId: threadId,
+      ts,
+      payload: { message },
+    });
+    return { message, ts };
   }
 
   /** Unilateral -- either party can close a thread without the other

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1365,6 +1365,319 @@ test("POST /v1/designs/check: the async semantic-conflict comparator opens an al
   assert.ok(bobNoticesBody.items.some((n) => n.message === "they fight over the same guarantee"));
 });
 
+// Found live (2026-08-26): runSemanticComparatorPass only ever checks the
+// *current* design being registered/amended against everything else
+// already open -- one-directional by construction. When bob's registration
+// gets checked against alice's open design, then alice's own later amend
+// gets checked against bob's, those used to land in two separate threads
+// (developerId/otherDeveloperId reversed) for what's really one
+// disagreement between one pair of designs -- confirmed live as two open
+// threads for the same tension. alignment-store.ts's findOrCreate now
+// recognizes the reverse direction and reuses the one thread instead.
+test("POST /v1/designs/check: a bidirectional llm_divergence -- both developers' own checks flagging the same pair -- lands in one shared thread, not two", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir); // alice
+
+  const aliceRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-alice", summary: "alice's retention sweep", creates: [], touches: ["src/activity-log.ts"], dependsOn: [] }),
+  });
+  const { designId: aliceDesignId } = (await aliceRes.json()) as { designId: string };
+
+  const inviteRes = await app.request("/v1/projects/proj-1/invites", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ label: "bob@example.com", role: "member" }),
+  });
+  const invite = (await inviteRes.json()) as { code: string };
+  await app.request(`/v1/invites/${invite.code}/redeem`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tokenHash: sha256Hex("bobs-pat"), label: "bob@example.com" }),
+  });
+
+  let bobDesignId: string | undefined;
+  await withBedrockEnv(async () => {
+    await withMockFetch(
+      (async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify({ conflict: true, kind: "tension", reason: "they fight over the same guarantee" }) } }] }), {
+          status: 200,
+        })) as typeof fetch,
+      async () => {
+        const bobRes = await app.request("/v1/designs/check", {
+          method: "POST",
+          headers: { "content-type": "application/json", ...bearer("bobs-pat") },
+          body: JSON.stringify({ projectId: "proj-1", sessionId: "s-bob", summary: "bob's audit permanence work", creates: [], touches: ["src/identity-store.ts"], dependsOn: [] }),
+        });
+        bobDesignId = ((await bobRes.json()) as { designId: string }).designId;
+        await waitFor(async () => {
+          const res = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(admin.token) });
+          const body = (await res.json()) as { items: unknown[] };
+          return body.items.length > 0;
+        });
+      },
+    );
+  });
+
+  let threadsRes = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(admin.token) });
+  let threadsBody = (await threadsRes.json()) as { items: { id: string; initiatingDesignId?: string; designId?: string }[] };
+  assert.equal(threadsBody.items.length, 1, "sanity: bob's check opened exactly one thread");
+  const threadId = threadsBody.items[0].id;
+  assert.equal(threadsBody.items[0].initiatingDesignId, bobDesignId);
+  assert.equal(threadsBody.items[0].designId, aliceDesignId);
+
+  // Alice's own work amends her original design -- her own one-directional
+  // check runs against bob's now-flagged (still counts as "open" for
+  // comparison purposes) design, reporting the same tension from the other
+  // side.
+  await withBedrockEnv(async () => {
+    await withMockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: JSON.stringify({ conflict: true, kind: "tension", reason: "still fighting over the same guarantee, alice's side" }) } }] }),
+          { status: 200 },
+        )) as typeof fetch,
+      async () => {
+        await app.request(`/v1/designs/${aliceDesignId}/amend`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...bearer(admin.token) },
+          body: JSON.stringify({ addTouches: ["src/activity-log-extra.ts"] }),
+        });
+        await waitFor(async () => {
+          const res = await app.request(`/v1/alignment-threads/${threadId}`, { headers: bearer(admin.token) });
+          if (res.status !== 200) return false;
+          const body = (await res.json()) as { messages: { message: string }[] };
+          return body.messages.some((m) => m.message === "still fighting over the same guarantee, alice's side");
+        });
+      },
+    );
+  });
+
+  threadsRes = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(admin.token) });
+  threadsBody = (await threadsRes.json()) as { items: { id: string; initiatingDesignId?: string; designId?: string }[] };
+  assert.equal(threadsBody.items.length, 1, "bob-initiated and alice-initiated findings for the same pair must share one thread, not fork a second");
+  assert.equal(threadsBody.items[0].id, threadId);
+  assert.equal(threadsBody.items[0].initiatingDesignId, bobDesignId, "the first flagger stays the recorded initiator");
+  assert.equal(threadsBody.items[0].designId, aliceDesignId);
+});
+
+// Found live (2026-08-26): resolving a design's block (self-approve or
+// admin-decide, both end in DesignRegistry.decideReview) never touched the
+// paired alignment thread at all -- a genuinely-resolved conflict and one
+// nobody ever came back to looked identical from the thread's own point of
+// view, both just sitting "open" forever with no trace of what happened.
+test("POST /v1/designs/:id/resolve: self-approving an llm_divergence block posts a system note into its alignment thread", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir); // alice
+
+  await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-alice", summary: "alice's retention sweep", creates: [], touches: ["src/activity-log.ts"], dependsOn: [] }),
+  });
+
+  const inviteRes = await app.request("/v1/projects/proj-1/invites", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ label: "bob@example.com", role: "member" }),
+  });
+  const invite = (await inviteRes.json()) as { code: string };
+  await app.request(`/v1/invites/${invite.code}/redeem`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tokenHash: sha256Hex("bobs-pat"), label: "bob@example.com" }),
+  });
+
+  let bobDesignId: string | undefined;
+  let threadId: string | undefined;
+  await withBedrockEnv(async () => {
+    await withMockFetch(
+      (async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify({ conflict: true, kind: "tension", reason: "they fight over the same guarantee" }) } }] }), {
+          status: 200,
+        })) as typeof fetch,
+      async () => {
+        const bobRes = await app.request("/v1/designs/check", {
+          method: "POST",
+          headers: { "content-type": "application/json", ...bearer("bobs-pat") },
+          body: JSON.stringify({ projectId: "proj-1", sessionId: "s-bob", summary: "bob's audit permanence work", creates: [], touches: ["src/identity-store.ts"], dependsOn: [] }),
+        });
+        bobDesignId = ((await bobRes.json()) as { designId: string }).designId;
+        await waitFor(async () => {
+          const res = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(admin.token) });
+          const body = (await res.json()) as { items: { id: string }[] };
+          if (body.items.length === 0) return false;
+          threadId = body.items[0].id;
+          return true;
+        });
+      },
+    );
+  });
+
+  const resolveRes = await app.request(`/v1/designs/${bobDesignId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer("bobs-pat") },
+    body: JSON.stringify({ resolution: "justified_divergence", justification: "reviewed with alice offline, proceeding" }),
+  });
+  const resolveBody = (await resolveRes.json()) as { status: string };
+  assert.equal(resolveBody.status, "resolved", "no constraint hits -- self-approves immediately");
+
+  const threadRes = await app.request(`/v1/alignment-threads/${threadId}`, { headers: bearer(admin.token) });
+  const threadBody = (await threadRes.json()) as { thread: { status: string }; messages: { message: string; authorId?: string }[] };
+  assert.equal(threadBody.thread.status, "open", "resolving the design must not itself close the conversation -- that stays a separate, human action");
+  const resolutionNote = threadBody.messages.find((m) => m.message.includes("Resolved"));
+  assert.ok(resolutionNote, "the thread must show the block was actually cleared, not just look abandoned");
+  assert.match(resolutionNote!.message, /bob@example\.com/);
+  assert.match(resolutionNote!.message, /reviewed with alice offline, proceeding/);
+  assert.equal(resolutionNote!.authorId, undefined, "a system note, not posted as either party");
+});
+
+// The reverse-direction merge (just above) means both sides' resolutions
+// now land in the *same* thread -- this is what actually answers "who
+// unblocked themselves and who didn't" from one place, rather than two
+// disconnected threads each showing half the picture.
+test("POST /v1/designs/:id/resolve: both sides independently self-approving a shared llm_divergence thread each post their own resolution note", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir); // alice
+
+  const aliceRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-alice", summary: "alice's retention sweep", creates: [], touches: ["src/activity-log.ts"], dependsOn: [] }),
+  });
+  const { designId: aliceDesignId } = (await aliceRes.json()) as { designId: string };
+
+  const inviteRes = await app.request("/v1/projects/proj-1/invites", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ label: "bob@example.com", role: "member" }),
+  });
+  const invite = (await inviteRes.json()) as { code: string };
+  await app.request(`/v1/invites/${invite.code}/redeem`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tokenHash: sha256Hex("bobs-pat"), label: "bob@example.com" }),
+  });
+
+  let bobDesignId: string | undefined;
+  let threadId: string | undefined;
+  await withBedrockEnv(async () => {
+    await withMockFetch(
+      (async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify({ conflict: true, kind: "tension", reason: "they fight over the same guarantee" }) } }] }), {
+          status: 200,
+        })) as typeof fetch,
+      async () => {
+        const bobRes = await app.request("/v1/designs/check", {
+          method: "POST",
+          headers: { "content-type": "application/json", ...bearer("bobs-pat") },
+          body: JSON.stringify({ projectId: "proj-1", sessionId: "s-bob", summary: "bob's audit permanence work", creates: [], touches: ["src/identity-store.ts"], dependsOn: [] }),
+        });
+        bobDesignId = ((await bobRes.json()) as { designId: string }).designId;
+        await waitFor(async () => {
+          const res = await app.request("/v1/alignment-threads?projectId=proj-1", { headers: bearer(admin.token) });
+          const body = (await res.json()) as { items: { id: string }[] };
+          if (body.items.length === 0) return false;
+          threadId = body.items[0].id;
+          return true;
+        });
+      },
+    );
+  });
+
+  // Bob resolves his side first.
+  await app.request(`/v1/designs/${bobDesignId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer("bobs-pat") },
+    body: JSON.stringify({ resolution: "justified_divergence", justification: "bob's justification" }),
+  });
+
+  // Alice's own registration also got flagged against bob's (reverse
+  // direction, same shared thread) -- resolve hers too.
+  await withBedrockEnv(async () => {
+    await withMockFetch(
+      (async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify({ conflict: true, kind: "tension", reason: "alice's side of the same tension" }) } }] }), {
+          status: 200,
+        })) as typeof fetch,
+      async () => {
+        await app.request(`/v1/designs/${aliceDesignId}/amend`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...bearer(admin.token) },
+          body: JSON.stringify({ addTouches: ["src/activity-log-extra.ts"] }),
+        });
+        await waitFor(async () => {
+          const res = await app.request(`/v1/alignment-threads/${threadId}`, { headers: bearer(admin.token) });
+          const body = (await res.json()) as { messages: { message: string }[] };
+          return body.messages.some((m) => m.message === "alice's side of the same tension");
+        });
+      },
+    );
+  });
+
+  const aliceResolveRes = await app.request(`/v1/designs/${aliceDesignId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ resolution: "justified_divergence", justification: "alice's justification" }),
+  });
+  assert.equal((await aliceResolveRes.json() as { status: string }).status, "resolved");
+
+  const threadRes = await app.request(`/v1/alignment-threads/${threadId}`, { headers: bearer(admin.token) });
+  const threadBody = (await threadRes.json()) as { messages: { message: string }[] };
+  const resolutionNotes = threadBody.messages.filter((m) => m.message.includes("Resolved"));
+  assert.equal(resolutionNotes.length, 2, "both sides' resolutions must show up, in the one shared thread");
+  assert.ok(resolutionNotes.some((m) => m.message.includes("bob@example.com") && m.message.includes("bob's justification")));
+  assert.ok(resolutionNotes.some((m) => m.message.includes("alice@example.com") && m.message.includes("alice's justification")));
+});
+
+test("POST /v1/designs/:id/resolve: self-approving a symbol_conflict block posts a system note into the shared thread, for either side", async () => {
+  const { app, dataDir } = freshApp();
+  const { alice, bobToken } = await fixtureWithOpenDesignAndSecondDeveloper(app, dataDir); // alice's design already covers src/x.ts
+
+  const bobDesignRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(bobToken) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-bob", summary: "bob's own work", creates: [], touches: ["src/y.ts"], dependsOn: [] }),
+  });
+  const { designId: bobDesignId } = (await bobDesignRes.json()) as { designId: string };
+
+  const claimRes = await app.request("/v1/claims", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(bobToken) },
+    body: JSON.stringify({ projectId: "proj-1", claims: [makeClaim({ projectId: "proj-1", sessionId: "s-bob", symbolId: "src/x.ts::f" })] }),
+  });
+  const { findings } = (await claimRes.json()) as { findings: { kind: string; threadId?: string }[] };
+  const threadId = findings.find((f) => f.kind === "design_divergence")!.threadId!;
+
+  // Get alice's design id (the one intruded upon) from the thread itself.
+  const beforeRes = await app.request(`/v1/alignment-threads/${threadId}`, { headers: bearer(alice.token) });
+  const aliceDesignId = ((await beforeRes.json()) as { thread: { designId?: string } }).thread.designId!;
+
+  // Bob (the intruder) resolves his own side first.
+  const bobResolveRes = await app.request(`/v1/designs/${bobDesignId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(bobToken) },
+    body: JSON.stringify({ resolution: "justified_divergence", justification: "bob's justification" }),
+  });
+  assert.equal((await bobResolveRes.json() as { status: string }).status, "resolved");
+
+  // Alice (the intruded-upon party) independently resolves hers too.
+  const aliceResolveRes = await app.request(`/v1/designs/${aliceDesignId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(alice.token) },
+    body: JSON.stringify({ resolution: "justified_divergence", justification: "alice's justification" }),
+  });
+  assert.equal((await aliceResolveRes.json() as { status: string }).status, "resolved");
+
+  const afterRes = await app.request(`/v1/alignment-threads/${threadId}`, { headers: bearer(alice.token) });
+  const afterBody = (await afterRes.json()) as { messages: { message: string }[] };
+  const resolutionNotes = afterBody.messages.filter((m) => m.message.includes("Resolved"));
+  assert.equal(resolutionNotes.length, 2, "both the initiator and the referenced side must each show up as resolved");
+  assert.ok(resolutionNotes.some((m) => m.message.includes("bob@example.com") && m.message.includes("bob's justification")));
+  assert.ok(resolutionNotes.some((m) => m.message.includes("alice@example.com") && m.message.includes("alice's justification")));
+});
+
 test("POST /v1/designs/check: the async semantic-conflict comparator produces no side effects when it finds nothing", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -11,7 +11,7 @@
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import type { Claim, CallEdge, DesignStatement, DesignConstraintType, Finding } from "@twing/core";
+import type { Claim, CallEdge, DesignStatement, DesignConstraintType, Finding, PendingReview } from "@twing/core";
 import { type Db, createDb } from "./db/client.js";
 import { Store } from "./store.js";
 import { findClaimConflicts, type ClaimFindingMatch } from "./checks.js";
@@ -557,6 +557,52 @@ export function createApp(options: CreateAppOptions = {}) {
         });
       }
     })().catch((err) => console.error("twing serve: semantic conflict check failed", err));
+  }
+
+  /** (2026-08-26) Resolving a design's block -- self-approve or admin-decide,
+   * both end in `designs.decideReview` -- never touched the paired
+   * alignment thread at all: `findOrCreate`/`postMessage`/`close` are the
+   * only writers, and neither decide path calls any of them. From the
+   * thread's own point of view, a conflict that got justified and cleared
+   * within a minute looked identical to one nobody ever came back to --
+   * both just sat "open" forever with no trace of what happened, found
+   * live investigating why real production threads looked unresolved.
+   *
+   * Posts one system note per thread this decision actually settles, read
+   * back from the review's own already-computed `conflictWaivers`/
+   * `symbolConflictWaivers` (not re-derived -- those were fixed at
+   * justify-time). Both waiver kinds are symmetric now (2026-08-26,
+   * alignment-store.ts's `findOrCreate` reverse-direction fix): either
+   * waiver list can point at a thread where this design is the
+   * `initiatingDesignId` *or* the referenced `designId`, so both are
+   * checked. Deliberately does not close the thread -- closing stays a
+   * separate, human decision (see this repo's own plan doc's "explicitly
+   * out of scope" note); this only makes an already-resolved block visibly
+   * resolved instead of indistinguishable from an abandoned one. */
+  function notifyAlignmentThreadsOfDecision(review: PendingReview, decision: "approve" | "reject"): void {
+    const design = designs.get(review.designId);
+    const who = design?.developerId ?? review.projectId;
+    const note = `Resolved: ${who}'s design was ${decision}d -- "${review.justification}"`;
+    const openThreads = alignmentThreads.listByProject(review.projectId, "open");
+
+    for (const w of review.conflictWaivers ?? []) {
+      const thread = openThreads.find(
+        (t) =>
+          t.category === "llm_divergence" &&
+          ((t.initiatingDesignId === review.designId && t.designId === w.conflictingDesignId) ||
+            (t.designId === review.designId && t.initiatingDesignId === w.conflictingDesignId)),
+      );
+      if (thread) alignmentThreads.postSystemMessage(thread.id, note);
+    }
+    for (const w of review.symbolConflictWaivers ?? []) {
+      const thread = openThreads.find(
+        (t) =>
+          t.category === "symbol_conflict" &&
+          ((t.initiatingDesignId === review.designId && t.designId === w.conflictingDesignId) ||
+            (t.designId === review.designId && t.initiatingDesignId === w.conflictingDesignId)),
+      );
+      if (thread) alignmentThreads.postSystemMessage(thread.id, note);
+    }
   }
 
   /** Shared by `/v1/designs/:id/amend` and `/v1/designs/:id/resume`: builds
@@ -1132,10 +1178,23 @@ export function createApp(options: CreateAppOptions = {}) {
     // `symbolConflictWaivers` below, which needed the same read-back and
     // would otherwise have copied the same dead pattern next to a working
     // one. See PendingReview.conflictWaivers' own doc comment (@twing/core).
+    //
+    // 2026-08-26, second fix, same day: `initiatingDesignId`-only was
+    // correct back when each side of an llm_divergence pair always got its
+    // *own* separate thread (each one-directional `runSemanticComparatorPass`
+    // call forked a new thread, so "am I the initiator" and "do I have a
+    // thread at all" were the same question). Now that `findOrCreate`
+    // recognizes the reverse direction and reuses one shared thread per
+    // pair (see its own doc comment, alignment-store.ts), the side that
+    // *wasn't* first to trigger the check can show up as the thread's
+    // `designId` instead of its `initiatingDesignId` -- same both-sides
+    // shape `symbolConflictWaivers` below already has to handle, for the
+    // same reason.
     const conflictWaivers = alignmentThreads
       .listByProject(design.projectId, "open")
-      .filter((t) => t.category === "llm_divergence" && t.initiatingDesignId === design.id && t.designId)
-      .map((t) => ({ conflictingDesignId: t.designId! }));
+      .filter((t) => t.category === "llm_divergence" && (t.initiatingDesignId === design.id || t.designId === design.id))
+      .map((t) => ({ conflictingDesignId: (t.initiatingDesignId === design.id ? t.designId : t.initiatingDesignId)! }))
+      .filter((w) => w.conflictingDesignId);
     // `symbolConflictWaivers` (2026-08-26, new bucket): unlike llm_divergence
     // above, a `symbol_conflict` finding can flag *both* sides independently
     // (`recordSymbolConflict`, app.ts's `/v1/claims` handler) -- so this
@@ -1173,6 +1232,7 @@ export function createApp(options: CreateAppOptions = {}) {
     // has.
     if (constraintHits.length === 0) {
       designs.decideReview(review.id, "approve");
+      notifyAlignmentThreadsOfDecision(review, "approve");
       return c.json({ status: "resolved", reviewId: review.id });
     }
     return c.json({ status: "pending_review", reviewId: review.id });
@@ -1628,6 +1688,7 @@ export function createApp(options: CreateAppOptions = {}) {
       return c.json({ error: "expected decision: approve | reject" }, 400);
     }
     const decided = designs.decideReview(id, body.decision);
+    if (decided) notifyAlignmentThreadsOfDecision(decided, body.decision);
     console.log(`twing serve: review ${id.slice(0, 8)} decided -> ${body.decision}`);
     return c.json({ review: decided });
   });


### PR DESCRIPTION
## Summary
Resolving a design's block (self-approve or admin-decide) never touched its paired alignment thread -- from the thread's own point of view, a conflict that got justified and cleared looked identical to one nobody ever came back to. Both just sat `open` forever with no trace of what happened. Found live while investigating why real production threads looked unresolved.

## Fixes
- `alignment-store.ts`: new `postSystemMessage` (author-less, same pattern as the existing seed note).
- `app.ts`: `notifyAlignmentThreadsOfDecision` posts a system note (`"Resolved: <dev>'s design was approved/rejected -- '<justification>'"`) into every thread a decision actually settles. Wired into both `/v1/designs/:id/resolve`'s self-approve branch and `/v1/reviews/:id/decide`. Thread stays `open` -- closing remains a separate, human decision.
- Also fixes a related bug this surfaced: `llm_divergence` threads forked by direction (each side's one-directional check created its own thread instead of sharing one), same bug class as the 2026-08-23 symbolId dedup fix. `findOrCreate` now also matches the reverse shape, so both directions share one thread -- matching `symbol_conflict`'s existing behavior. This also fixed a latent bug in `conflictWaivers` computation that only checked `initiatingDesignId`.

## Testing
8 new tests (dedup-reversal unit + edge case, system-message unit, llm_divergence and symbol_conflict resolution-notification integration tests). Full workspace green: 318 server / 112 CLI / 34 core, clean build. No schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
