### PR TITLE
[Yet to test] Add Bifrost, OpenRouter, and Vertex AI as selectable LLM providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,15 +282,19 @@ node simulator/dist/index.js --enable-design-gate   # also exercise §17
     `design-checks.ts` (verdict logic: `clean`/`overlap`/`constraint_flag`),
     `design-store.ts` (`DesignRegistry`, `ConstraintStore`), `design-extract.ts`
     (turns free-text plan into structured `creates`/`touches`/`dependsOn` via
-    one LLM chat-completion call routed by `llm-client.ts`. AWS Bedrock
-    (`bedrock-mantle`, `AWS_BEARER_TOKEN_BEDROCK`) is the default provider;
-    Bifrost (`TWING_BIFROST_BASE_URL`), OpenRouter (`OPENROUTER_API_KEY`),
-    and GCP Vertex AI (`GOOGLE_APPLICATION_CREDENTIALS`) are also selectable
-    via `TWING_LLM_PROVIDER` or credential auto-detection, Bedrock winning
-    ties — all four share the OpenAI chat-completions shape; Vertex mints its
-    OAuth token from the service-account key with `node:crypto`, no
-    `google-auth-library`. Missing/misconfigured credentials fail soft to
-    "clean", never deny over it). `/v1/constraints/match` is
+    one LLM chat-completion call routed by `llm-client.ts`. The provider is
+    auto-detected — no `TWING_LLM_PROVIDER` — from which credential/base-URL
+    var is set, precedence `AWS_BEARER_TOKEN_BEDROCK` (Bedrock/`bedrock-mantle`)
+    → `GOOGLE_APPLICATION_CREDENTIALS` (GCP Vertex AI) → `OPENROUTER_API_KEY`
+    → `TWING_BIFROST_BASE_URL`; `selectProvider` **throws** when none is set
+    (no default) and the caller's retry loop fails soft over it. All four
+    share the OpenAI chat-completions shape; Vertex auth is
+    `google-auth-library` (`GoogleAuth` — service-account JSON / ADC / GCE
+    metadata). Model is per-provider: `resolveExtractModel` /
+    `resolveSemanticCheckModel` read `TWING_<PROVIDER>_EXTRACT_MODEL` /
+    `TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL` with a provider-appropriate
+    default. Missing/misconfigured credentials fail soft to "clean", never
+    deny over it). `/v1/constraints/match` is
     the §17.9 ground-truth backstop: checks the literal file path against the
     Constraint Store directly, independent of what the session's registered
     design claims to touch (closes a bypass where a session registers an
@@ -456,10 +460,14 @@ Claude Code tool call
   different clones/worktrees.
 - `developerId` — server-issued and auth-derived (§17.10 hardening): resolved
   from the authenticated PAT on every request, not read from a client-supplied
-  field. `computeDeveloperId()` (git-email-derived, local) survives only as
-  the suggested label at `keygen`/`admin bootstrap` time and for `align.ts`'s
-  no-server git-diff fallback, which never talks to a server to verify
-  anything against.
+  field. The *label* it's minted from is chosen once, client-side, at
+  identity-creation time, resolving in order: an explicit `--label`, then the
+  caller's GitHub username (via the OAuth token `join.ts` already holds, or a
+  best-effort `computeGithubUsername()` — `gh` CLI / `git config github.user`
+  — on the `keygen`/`admin bootstrap` paths that have no token), then
+  `computeDeveloperId()` (git-email-derived, local), then a persisted random
+  id. `computeDeveloperId()` also still backs `align.ts`'s no-server git-diff
+  fallback, which never talks to a server to verify anything against.
 - `sessionId` — Claude Code's real session id. The design gate's `Edit`/
   `Write` check looks open designs up by exact session id; it comes from
   `CLAUDE_CODE_SESSION_ID` by default (confirmed live against a real gated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,15 @@ node simulator/dist/index.js --enable-design-gate   # also exercise §17
     `design-checks.ts` (verdict logic: `clean`/`overlap`/`constraint_flag`),
     `design-store.ts` (`DesignRegistry`, `ConstraintStore`), `design-extract.ts`
     (turns free-text plan into structured `creates`/`touches`/`dependsOn` via
-    a Bedrock LLM call (the sole LLM provider — OpenRouter support was
-    removed 2026-08-17) — `AWS_BEARER_TOKEN_BEDROCK`; missing credentials
-    fail soft to "clean", never deny over it). `/v1/constraints/match` is
+    one LLM chat-completion call routed by `llm-client.ts`. AWS Bedrock
+    (`bedrock-mantle`, `AWS_BEARER_TOKEN_BEDROCK`) is the default provider;
+    Bifrost (`TWING_BIFROST_BASE_URL`), OpenRouter (`OPENROUTER_API_KEY`),
+    and GCP Vertex AI (`GOOGLE_APPLICATION_CREDENTIALS`) are also selectable
+    via `TWING_LLM_PROVIDER` or credential auto-detection, Bedrock winning
+    ties — all four share the OpenAI chat-completions shape; Vertex mints its
+    OAuth token from the service-account key with `node:crypto`, no
+    `google-auth-library`. Missing/misconfigured credentials fail soft to
+    "clean", never deny over it). `/v1/constraints/match` is
     the §17.9 ground-truth backstop: checks the literal file path against the
     Constraint Store directly, independent of what the session's registered
     design claims to touch (closes a bypass where a session registers an

--- a/README.md
+++ b/README.md
@@ -309,8 +309,10 @@ npm run start --workspace packages/server
 # (GOOGLE_APPLICATION_CREDENTIALS / gcloud ADC / GCE metadata server)
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
 export GOOGLE_CLOUD_PROJECT=my-project      # or resolved from the credentials
-export GOOGLE_CLOUD_LOCATION=us-central1    # optional; default "global" (uses the location-less aiplatform.googleapis.com host)
-# export TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash   # default
+export GOOGLE_CLOUD_LOCATION=global         # optional; "global" (the default) uses the location-less aiplatform.googleapis.com host
+# Gemma via Vertex MaaS, for example (default when unset: google/gemini-2.0-flash):
+export TWING_VERTEX_EXTRACT_MODEL="google/gemma-4-26b-a4b-it-maas"
+export TWING_VERTEX_SEMANTIC_CHECK_MODEL="google/gemma-4-26b-a4b-it-maas"
 
 # OpenRouter
 export OPENROUTER_API_KEY=...

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ npm run start --workspace packages/server
 # (GOOGLE_APPLICATION_CREDENTIALS / gcloud ADC / GCE metadata server)
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
 export GOOGLE_CLOUD_PROJECT=my-project      # or resolved from the credentials
-export GOOGLE_CLOUD_LOCATION=us-central1    # optional, this is the default
+export GOOGLE_CLOUD_LOCATION=us-central1    # optional; default "global" (uses the location-less aiplatform.googleapis.com host)
 # export TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash   # default
 
 # OpenRouter

--- a/README.md
+++ b/README.md
@@ -288,13 +288,38 @@ scripts for running it as a systemd service under an isolated,
 unprivileged user instead -- see `deploy/README.md`.
 
 **Design checks made from plan text** (`ExitPlanMode`) need an LLM call to
-turn the plan into structured fields, so wherever this runs needs Bedrock
-credentials (the sole LLM provider):
+turn the plan into structured fields, so wherever this runs needs an LLM
+provider configured. AWS Bedrock (`bedrock-mantle`) is the default:
 
 ```sh
 export AWS_BEARER_TOKEN_BEDROCK=...
 export AWS_REGION=us-east-1
 npm run start --workspace packages/server
+```
+
+Three alternatives are also selectable -- pick one explicitly with
+`TWING_LLM_PROVIDER=bedrock|bifrost|openrouter|vertex`, or just set that
+provider's vars and let the server auto-detect (Bedrock wins if more than
+one is configured). For Bifrost/OpenRouter/Vertex you must also point
+`TWING_EXTRACT_MODEL` / `TWING_SEMANTIC_CHECK_MODEL` at a model string that
+provider understands (e.g. `openai/gpt-4o-mini`), since the default is a
+Bedrock model id.
+
+```sh
+# Bifrost gateway (https://docs.getbifrost.ai)
+export TWING_BIFROST_BASE_URL=http://localhost:8080
+export TWING_BIFROST_API_KEY=...        # optional; sk-bf-* sent as x-bf-vk, else Bearer
+export TWING_EXTRACT_MODEL=openai/gpt-4o-mini
+export TWING_SEMANTIC_CHECK_MODEL=openai/gpt-4o-mini
+
+# OpenRouter
+export OPENROUTER_API_KEY=...
+export OPENROUTER_BASE_URL=...          # optional, defaults to https://openrouter.ai/api/v1
+
+# GCP Vertex AI (service-account JSON; no google-auth-library needed)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+export GOOGLE_CLOUD_PROJECT=my-project
+export GOOGLE_CLOUD_LOCATION=us-central1   # optional, this is the default
 ```
 
 **Onboarding a non-GitHub-hosted project** (GitLab, self-hosted git, no

--- a/README.md
+++ b/README.md
@@ -289,37 +289,38 @@ unprivileged user instead -- see `deploy/README.md`.
 
 **Design checks made from plan text** (`ExitPlanMode`) need an LLM call to
 turn the plan into structured fields, so wherever this runs needs an LLM
-provider configured. AWS Bedrock (`bedrock-mantle`) is the default:
+provider configured. The provider is **auto-detected** from which of these
+env vars is set, in precedence order **AWS → GCP → OpenRouter → Bifrost**;
+if none is set the plan-text check fails soft to "clean" (the
+`Edit`/`Write` "must have a registered design" rule still applies). Each
+provider also carries its own model config -- `TWING_<PROVIDER>_EXTRACT_MODEL`
+/ `TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL`, each defaulting to something
+sensible for that provider -- so switching providers doesn't leave a
+stale model id behind.
 
 ```sh
+# AWS Bedrock (bedrock-mantle)
 export AWS_BEARER_TOKEN_BEDROCK=...
 export AWS_REGION=us-east-1
+# export TWING_BEDROCK_EXTRACT_MODEL=google.gemma-4-31b   # default
 npm run start --workspace packages/server
-```
 
-Three alternatives are also selectable -- pick one explicitly with
-`TWING_LLM_PROVIDER=bedrock|bifrost|openrouter|vertex`, or just set that
-provider's vars and let the server auto-detect (Bedrock wins if more than
-one is configured). For Bifrost/OpenRouter/Vertex you must also point
-`TWING_EXTRACT_MODEL` / `TWING_SEMANTIC_CHECK_MODEL` at a model string that
-provider understands (e.g. `openai/gpt-4o-mini`), since the default is a
-Bedrock model id.
-
-```sh
-# Bifrost gateway (https://docs.getbifrost.ai)
-export TWING_BIFROST_BASE_URL=http://localhost:8080
-export TWING_BIFROST_API_KEY=...        # optional; sk-bf-* sent as x-bf-vk, else Bearer
-export TWING_EXTRACT_MODEL=openai/gpt-4o-mini
-export TWING_SEMANTIC_CHECK_MODEL=openai/gpt-4o-mini
+# GCP Vertex AI -- credentials via google-auth-library
+# (GOOGLE_APPLICATION_CREDENTIALS / gcloud ADC / GCE metadata server)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+export GOOGLE_CLOUD_PROJECT=my-project      # or resolved from the credentials
+export GOOGLE_CLOUD_LOCATION=us-central1    # optional, this is the default
+# export TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash   # default
 
 # OpenRouter
 export OPENROUTER_API_KEY=...
-export OPENROUTER_BASE_URL=...          # optional, defaults to https://openrouter.ai/api/v1
+export OPENROUTER_BASE_URL=...              # optional, defaults to https://openrouter.ai/api/v1
+# export TWING_OPENROUTER_EXTRACT_MODEL=openai/gpt-4o-mini    # default
 
-# GCP Vertex AI (service-account JSON; no google-auth-library needed)
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
-export GOOGLE_CLOUD_PROJECT=my-project
-export GOOGLE_CLOUD_LOCATION=us-central1   # optional, this is the default
+# Bifrost gateway (https://docs.getbifrost.ai)
+export TWING_BIFROST_BASE_URL=http://localhost:8080
+export TWING_BIFROST_API_KEY=...            # optional; sk-bf-* sent as x-bf-vk, else Bearer
+# export TWING_BIFROST_EXTRACT_MODEL=openai/gpt-4o-mini       # default
 ```
 
 **Onboarding a non-GitHub-hosted project** (GitLab, self-hosted git, no

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,8 +35,10 @@ build yet.
 
 `start-server.sh` just inherits whatever's already in your shell's
 environment, so export these first if you want the design-conflict gate's
-plan-text extraction working. Bedrock is the sole LLM provider (OpenRouter
-support was removed 2026-08-17):
+plan-text extraction working. AWS Bedrock (`bedrock-mantle`) is the default
+LLM provider; Bifrost, OpenRouter, and GCP Vertex AI are also selectable
+(`TWING_LLM_PROVIDER=bedrock|bifrost|openrouter|vertex`, or auto-detected
+from whichever provider's vars are set -- Bedrock wins ties):
 
 ```sh
 export AWS_BEARER_TOKEN_BEDROCK=...
@@ -46,10 +48,29 @@ export TWING_SERVE_DATA_DIR=~/.twing/serve-data  # optional, this is the default
 deploy/start-server.sh
 ```
 
-None of these are required to start the server -- without `AWS_BEARER_TOKEN_BEDROCK`,
-`ExitPlanMode` checks fail soft to "clean" (logged), and the `Edit`/`Write`
-"you need a registered design" check still works either way, since it doesn't
-need extraction.
+Alternative providers (set `TWING_EXTRACT_MODEL` / `TWING_SEMANTIC_CHECK_MODEL`
+to that provider's own model string, e.g. `openai/gpt-4o-mini`, not the
+Bedrock default):
+
+```sh
+# Bifrost -- https://docs.getbifrost.ai
+export TWING_BIFROST_BASE_URL=http://localhost:8080
+export TWING_BIFROST_API_KEY=...        # optional; sk-bf-* -> x-bf-vk header, else Bearer
+
+# OpenRouter
+export OPENROUTER_API_KEY=...
+export OPENROUTER_BASE_URL=...          # optional, defaults to https://openrouter.ai/api/v1
+
+# GCP Vertex AI -- service-account JSON, no google-auth-library dependency
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+export GOOGLE_CLOUD_PROJECT=my-project
+export GOOGLE_CLOUD_LOCATION=us-central1   # optional, this is the default
+```
+
+None of these are required to start the server -- with no LLM provider fully
+configured, `ExitPlanMode` checks fail soft to "clean" (logged), and the
+`Edit`/`Write` "you need a registered design" check still works either way,
+since it doesn't need extraction.
 
 ### Auth (§17.10 hardening) -- per-developer PATs, always on
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -50,7 +50,7 @@ export AWS_REGION=us-east-1
 # ...or GCP Vertex AI -- credentials via google-auth-library
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
 export GOOGLE_CLOUD_PROJECT=my-project      # or resolved from the credentials
-export GOOGLE_CLOUD_LOCATION=us-central1    # optional, this is the default
+export GOOGLE_CLOUD_LOCATION=us-central1    # optional; default "global" (uses the location-less aiplatform.googleapis.com host)
 # export TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash   # default
 
 # ...or OpenRouter

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -50,8 +50,10 @@ export AWS_REGION=us-east-1
 # ...or GCP Vertex AI -- credentials via google-auth-library
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
 export GOOGLE_CLOUD_PROJECT=my-project      # or resolved from the credentials
-export GOOGLE_CLOUD_LOCATION=us-central1    # optional; default "global" (uses the location-less aiplatform.googleapis.com host)
-# export TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash   # default
+export GOOGLE_CLOUD_LOCATION=global         # optional; "global" (the default) uses the location-less aiplatform.googleapis.com host
+# Gemma via Vertex MaaS, for example (default when unset: google/gemini-2.0-flash):
+export TWING_VERTEX_EXTRACT_MODEL="google/gemma-4-26b-a4b-it-maas"
+export TWING_VERTEX_SEMANTIC_CHECK_MODEL="google/gemma-4-26b-a4b-it-maas"
 
 # ...or OpenRouter
 export OPENROUTER_API_KEY=...

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,39 +35,37 @@ build yet.
 
 `start-server.sh` just inherits whatever's already in your shell's
 environment, so export these first if you want the design-conflict gate's
-plan-text extraction working. AWS Bedrock (`bedrock-mantle`) is the default
-LLM provider; Bifrost, OpenRouter, and GCP Vertex AI are also selectable
-(`TWING_LLM_PROVIDER=bedrock|bifrost|openrouter|vertex`, or auto-detected
-from whichever provider's vars are set -- Bedrock wins ties):
+plan-text extraction working. The LLM provider is **auto-detected** from
+which vars are set, in precedence order **AWS → GCP → OpenRouter →
+Bifrost**. Each provider carries its own model via
+`TWING_<PROVIDER>_EXTRACT_MODEL` / `TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL`
+(each with a provider-appropriate default).
 
 ```sh
+# One provider block. AWS Bedrock (bedrock-mantle):
 export AWS_BEARER_TOKEN_BEDROCK=...
 export AWS_REGION=us-east-1
-export TWING_EXTRACT_MODEL=google.gemma-4-31b   # optional, this is the default
+# export TWING_BEDROCK_EXTRACT_MODEL=google.gemma-4-31b   # default
+
+# ...or GCP Vertex AI -- credentials via google-auth-library
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+export GOOGLE_CLOUD_PROJECT=my-project      # or resolved from the credentials
+export GOOGLE_CLOUD_LOCATION=us-central1    # optional, this is the default
+# export TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash   # default
+
+# ...or OpenRouter
+export OPENROUTER_API_KEY=...
+export OPENROUTER_BASE_URL=...              # optional, defaults to https://openrouter.ai/api/v1
+
+# ...or Bifrost -- https://docs.getbifrost.ai
+export TWING_BIFROST_BASE_URL=http://localhost:8080
+export TWING_BIFROST_API_KEY=...            # optional; sk-bf-* -> x-bf-vk header, else Bearer
+
 export TWING_SERVE_DATA_DIR=~/.twing/serve-data  # optional, this is the default -- where ratified constraints persist
 deploy/start-server.sh
 ```
 
-Alternative providers (set `TWING_EXTRACT_MODEL` / `TWING_SEMANTIC_CHECK_MODEL`
-to that provider's own model string, e.g. `openai/gpt-4o-mini`, not the
-Bedrock default):
-
-```sh
-# Bifrost -- https://docs.getbifrost.ai
-export TWING_BIFROST_BASE_URL=http://localhost:8080
-export TWING_BIFROST_API_KEY=...        # optional; sk-bf-* -> x-bf-vk header, else Bearer
-
-# OpenRouter
-export OPENROUTER_API_KEY=...
-export OPENROUTER_BASE_URL=...          # optional, defaults to https://openrouter.ai/api/v1
-
-# GCP Vertex AI -- service-account JSON, no google-auth-library dependency
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
-export GOOGLE_CLOUD_PROJECT=my-project
-export GOOGLE_CLOUD_LOCATION=us-central1   # optional, this is the default
-```
-
-None of these are required to start the server -- with no LLM provider fully
+None of these are required to start the server -- with no LLM provider
 configured, `ExitPlanMode` checks fail soft to "clean" (logged), and the
 `Edit`/`Write` "you need a registered design" check still works either way,
 since it doesn't need extraction.

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -4,12 +4,41 @@
 # main.ts's own startup-log warnings for what each missing one degrades.
 
 # ExitPlanMode design-check extraction, and the async semantic-conflict
-# comparator, both call Bedrock (the sole LLM provider -- OpenRouter support
-# was removed 2026-08-17). Without these, extraction fails soft to "clean"
-# and the semantic comparator fails soft to "no conflict" -- the core
-# Edit/Write "you need a registered design" check still works either way.
+# comparator, both need an LLM provider. AWS Bedrock (bedrock-mantle) is the
+# default; Bifrost, OpenRouter, and GCP Vertex AI are also selectable. Pick
+# one with TWING_LLM_PROVIDER, or just fill in that provider's block below
+# and let the server auto-detect (Bedrock wins if more than one is set).
+# With none fully configured, extraction fails soft to "clean" and the
+# semantic comparator to "no conflict" -- the core Edit/Write "you need a
+# registered design" check still works either way.
+# TWING_LLM_PROVIDER=bedrock
+
+# --- Bedrock (default) ---
 AWS_BEARER_TOKEN_BEDROCK=
 AWS_REGION=
+
+# --- Bifrost gateway (https://docs.getbifrost.ai) ---
+# Also set TWING_EXTRACT_MODEL / TWING_SEMANTIC_CHECK_MODEL to a model string
+# this gateway understands (e.g. openai/gpt-4o-mini) -- the default is a
+# Bedrock model id. TWING_BIFROST_API_KEY is optional: an sk-bf-* value is
+# sent as the x-bf-vk header, anything else as Authorization: Bearer, unset
+# means no auth header (a keyless localhost gateway).
+TWING_BIFROST_BASE_URL=
+TWING_BIFROST_API_KEY=
+
+# --- OpenRouter ---
+OPENROUTER_API_KEY=
+# OPENROUTER_BASE_URL=            # optional, defaults to https://openrouter.ai/api/v1
+
+# --- GCP Vertex AI (service-account JSON; no google-auth-library) ---
+GOOGLE_APPLICATION_CREDENTIALS=
+GOOGLE_CLOUD_PROJECT=
+# GOOGLE_CLOUD_LOCATION=us-central1   # optional, this is the default
+
+# Model ids for the two LLM calls. Defaults to a Bedrock model id
+# (google.gemma-4-31b) -- override for Bifrost/OpenRouter/Vertex.
+# TWING_EXTRACT_MODEL=
+# TWING_SEMANTIC_CHECK_MODEL=
 
 # Lets a browser-based client (twing-monitor) call /v1/* cross-origin.
 # Unset/empty mounts no CORS middleware at all -- app.ts's corsOrigins doc

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -4,41 +4,42 @@
 # main.ts's own startup-log warnings for what each missing one degrades.
 
 # ExitPlanMode design-check extraction, and the async semantic-conflict
-# comparator, both need an LLM provider. AWS Bedrock (bedrock-mantle) is the
-# default; Bifrost, OpenRouter, and GCP Vertex AI are also selectable. Pick
-# one with TWING_LLM_PROVIDER, or just fill in that provider's block below
-# and let the server auto-detect (Bedrock wins if more than one is set).
-# With none fully configured, extraction fails soft to "clean" and the
-# semantic comparator to "no conflict" -- the core Edit/Write "you need a
-# registered design" check still works either way.
-# TWING_LLM_PROVIDER=bedrock
+# comparator, both need an LLM provider. The provider is auto-detected from
+# which block below you fill in, in precedence order AWS -> GCP -> OpenRouter
+# -> Bifrost (there is no TWING_LLM_PROVIDER override). With none configured,
+# extraction fails soft to "clean" and the semantic comparator to "no
+# conflict" -- the core Edit/Write "you need a registered design" check
+# still works either way. Fill in exactly one block.
 
-# --- Bedrock (default) ---
+# --- AWS Bedrock (bedrock-mantle) ---
 AWS_BEARER_TOKEN_BEDROCK=
 AWS_REGION=
+# TWING_BEDROCK_EXTRACT_MODEL=google.gemma-4-31b        # default
+# TWING_BEDROCK_SEMANTIC_CHECK_MODEL=google.gemma-4-31b # default
 
-# --- Bifrost gateway (https://docs.getbifrost.ai) ---
-# Also set TWING_EXTRACT_MODEL / TWING_SEMANTIC_CHECK_MODEL to a model string
-# this gateway understands (e.g. openai/gpt-4o-mini) -- the default is a
-# Bedrock model id. TWING_BIFROST_API_KEY is optional: an sk-bf-* value is
-# sent as the x-bf-vk header, anything else as Authorization: Bearer, unset
-# means no auth header (a keyless localhost gateway).
-TWING_BIFROST_BASE_URL=
-TWING_BIFROST_API_KEY=
+# --- GCP Vertex AI ---
+# Credentials via google-auth-library: a service-account JSON path here, or
+# gcloud application-default credentials, or the GCE metadata server.
+GOOGLE_APPLICATION_CREDENTIALS=
+GOOGLE_CLOUD_PROJECT=                                   # or resolved from the credentials
+# GOOGLE_CLOUD_LOCATION=us-central1                     # optional, this is the default
+# TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash    # default
+# TWING_VERTEX_SEMANTIC_CHECK_MODEL=google/gemini-2.0-flash
 
 # --- OpenRouter ---
 OPENROUTER_API_KEY=
-# OPENROUTER_BASE_URL=            # optional, defaults to https://openrouter.ai/api/v1
+# OPENROUTER_BASE_URL=                                  # optional, defaults to https://openrouter.ai/api/v1
+# TWING_OPENROUTER_EXTRACT_MODEL=openai/gpt-4o-mini     # default
+# TWING_OPENROUTER_SEMANTIC_CHECK_MODEL=openai/gpt-4o-mini
 
-# --- GCP Vertex AI (service-account JSON; no google-auth-library) ---
-GOOGLE_APPLICATION_CREDENTIALS=
-GOOGLE_CLOUD_PROJECT=
-# GOOGLE_CLOUD_LOCATION=us-central1   # optional, this is the default
-
-# Model ids for the two LLM calls. Defaults to a Bedrock model id
-# (google.gemma-4-31b) -- override for Bifrost/OpenRouter/Vertex.
-# TWING_EXTRACT_MODEL=
-# TWING_SEMANTIC_CHECK_MODEL=
+# --- Bifrost gateway (https://docs.getbifrost.ai) ---
+# TWING_BIFROST_API_KEY is optional: an sk-bf-* value is sent as the x-bf-vk
+# header, anything else as Authorization: Bearer, unset means no auth header
+# (a keyless localhost gateway).
+TWING_BIFROST_BASE_URL=
+TWING_BIFROST_API_KEY=
+# TWING_BIFROST_EXTRACT_MODEL=openai/gpt-4o-mini        # default
+# TWING_BIFROST_SEMANTIC_CHECK_MODEL=openai/gpt-4o-mini
 
 # Lets a browser-based client (twing-monitor) call /v1/* cross-origin.
 # Unset/empty mounts no CORS middleware at all -- app.ts's corsOrigins doc

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -22,7 +22,7 @@ AWS_REGION=
 # gcloud application-default credentials, or the GCE metadata server.
 GOOGLE_APPLICATION_CREDENTIALS=
 GOOGLE_CLOUD_PROJECT=                                   # or resolved from the credentials
-# GOOGLE_CLOUD_LOCATION=us-central1                     # optional, this is the default
+# GOOGLE_CLOUD_LOCATION=us-central1                     # optional; default "global" (location-less aiplatform.googleapis.com host)
 # TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash    # default
 # TWING_VERTEX_SEMANTIC_CHECK_MODEL=google/gemini-2.0-flash
 

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -22,9 +22,10 @@ AWS_REGION=
 # gcloud application-default credentials, or the GCE metadata server.
 GOOGLE_APPLICATION_CREDENTIALS=
 GOOGLE_CLOUD_PROJECT=                                   # or resolved from the credentials
-# GOOGLE_CLOUD_LOCATION=us-central1                     # optional; default "global" (location-less aiplatform.googleapis.com host)
-# TWING_VERTEX_EXTRACT_MODEL=google/gemini-2.0-flash    # default
-# TWING_VERTEX_SEMANTIC_CHECK_MODEL=google/gemini-2.0-flash
+GOOGLE_CLOUD_LOCATION=global                            # "global" (the default) uses the location-less aiplatform.googleapis.com host
+# Gemma via Vertex MaaS, for example (default when unset: google/gemini-2.0-flash):
+TWING_VERTEX_EXTRACT_MODEL=google/gemma-4-26b-a4b-it-maas
+TWING_VERTEX_SEMANTIC_CHECK_MODEL=google/gemma-4-26b-a4b-it-maas
 
 # --- OpenRouter ---
 OPENROUTER_API_KEY=

--- a/docs/orchestrator-and-verification-design-doc_v1.md
+++ b/docs/orchestrator-and-verification-design-doc_v1.md
@@ -775,18 +775,35 @@ signal, only consulted when the structured checks find nothing (§17.4).
 
 ### 17.3 Extraction
 
-`rawPlanText` → structured fields via one OpenRouter chat-completion call
-(`packages/server/src/design-extract.ts`), same call shape already used by
-`simulator/src/drivers/openrouter-driver.ts` (duplicated, not imported — the server
-package shouldn't depend on the simulator). Model: `TWING_EXTRACT_MODEL`, default
-`openai/gpt-oss-20b:free` (the simulator's existing default, kept for consistency and
-zero marginal cost while dogfooding). Key: `OPENROUTER_API_KEY` env var on the machine
-running `twing serve`.
+`rawPlanText` → structured fields via one chat-completion call
+(`packages/server/src/design-extract.ts`), routed through
+`packages/server/src/llm-client.ts`. All providers speak the OpenAI
+chat-completions request/response shape, so there is one call shape and one
+response parser regardless of which is active.
+
+**Provider** — AWS Bedrock (`bedrock-mantle`, a plain Bearer-token
+OpenAI-compat shim, not the Bedrock Runtime `Converse` API) is the default.
+Bifrost (`TWING_BIFROST_BASE_URL`, optional `TWING_BIFROST_API_KEY` — an
+`sk-bf-*` value goes as the `x-bf-vk` header, anything else as
+`Authorization: Bearer`), OpenRouter (`OPENROUTER_API_KEY`), and GCP Vertex
+AI (`GOOGLE_APPLICATION_CREDENTIALS` service-account JSON + `GOOGLE_CLOUD_PROJECT`
+/ `GOOGLE_CLOUD_LOCATION`) are also selectable. `TWING_LLM_PROVIDER`
+(`bedrock|bifrost|openrouter|vertex`) forces the choice; unset, `selectProvider`
+auto-detects from which credential/base-URL vars are present, Bedrock winning
+ties. Vertex mints its short-lived OAuth token from the service-account key
+via an RS256 JWT bearer grant done with `node:crypto` (no `google-auth-library`),
+cached in-process; the other three are single unauthenticated-SDK `fetch`
+calls. **Model**: `TWING_EXTRACT_MODEL` / `TWING_SEMANTIC_CHECK_MODEL`,
+default `google.gemma-4-31b` (a Bedrock model id — an operator pointing at
+Bifrost/OpenRouter/Vertex must set these to that provider's own
+`provider/model` string, e.g. `openai/gpt-4o-mini`).
 
 Schema-validated by hand on the way out (matches `manifest.ts`'s existing manual-parse
-style — no new dependency); one retry with a stricter prompt on malformed JSON. Unlike
+style — no new dependency); one retry on malformed JSON. Unlike
 the spec's "reject/retry," a second failure **fails soft**: empty `creates`/`touches`/
-`dependsOn`, verdict proceeds as `clean`, failure logged server-side. An extraction bug
+`dependsOn`, verdict proceeds as `clean`, failure logged server-side. This covers a
+missing/misconfigured provider too — the real call throws, retries once, then falls
+soft; there is no separate credential precheck. An extraction bug
 degrading to "no check ran" is the right failure mode for a blocking gate — degrading to
 "deny everyone" is not.
 

--- a/docs/orchestrator-and-verification-design-doc_v1.md
+++ b/docs/orchestrator-and-verification-design-doc_v1.md
@@ -781,22 +781,34 @@ signal, only consulted when the structured checks find nothing (§17.4).
 chat-completions request/response shape, so there is one call shape and one
 response parser regardless of which is active.
 
-**Provider** — AWS Bedrock (`bedrock-mantle`, a plain Bearer-token
-OpenAI-compat shim, not the Bedrock Runtime `Converse` API) is the default.
-Bifrost (`TWING_BIFROST_BASE_URL`, optional `TWING_BIFROST_API_KEY` — an
-`sk-bf-*` value goes as the `x-bf-vk` header, anything else as
-`Authorization: Bearer`), OpenRouter (`OPENROUTER_API_KEY`), and GCP Vertex
-AI (`GOOGLE_APPLICATION_CREDENTIALS` service-account JSON + `GOOGLE_CLOUD_PROJECT`
-/ `GOOGLE_CLOUD_LOCATION`) are also selectable. `TWING_LLM_PROVIDER`
-(`bedrock|bifrost|openrouter|vertex`) forces the choice; unset, `selectProvider`
-auto-detects from which credential/base-URL vars are present, Bedrock winning
-ties. Vertex mints its short-lived OAuth token from the service-account key
-via an RS256 JWT bearer grant done with `node:crypto` (no `google-auth-library`),
-cached in-process; the other three are single unauthenticated-SDK `fetch`
-calls. **Model**: `TWING_EXTRACT_MODEL` / `TWING_SEMANTIC_CHECK_MODEL`,
-default `google.gemma-4-31b` (a Bedrock model id — an operator pointing at
-Bifrost/OpenRouter/Vertex must set these to that provider's own
-`provider/model` string, e.g. `openai/gpt-4o-mini`).
+**Provider** — auto-detected by `selectProvider`, no `TWING_LLM_PROVIDER`
+override, from which credential/base-URL var is present, in precedence
+order:
+
+1. `AWS_BEARER_TOKEN_BEDROCK` → AWS Bedrock (`bedrock-mantle`, a plain
+   Bearer-token OpenAI-compat shim, not the Bedrock Runtime `Converse` API).
+2. `GOOGLE_APPLICATION_CREDENTIALS` → GCP Vertex AI's OpenAI-compat
+   endpoint. Auth is `google-auth-library`'s `GoogleAuth` (service-account
+   JSON / gcloud ADC / GCE metadata server; it refreshes and caches the
+   token itself). `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` override
+   the project (else resolved from the credentials) and region (default
+   `us-central1`).
+3. `OPENROUTER_API_KEY` → OpenRouter (`OPENROUTER_BASE_URL` optional).
+4. `TWING_BIFROST_BASE_URL` → Bifrost gateway (optional `TWING_BIFROST_API_KEY`
+   — an `sk-bf-*` value goes as the `x-bf-vk` header, anything else as
+   `Authorization: Bearer`, unset means no auth header).
+
+`selectProvider` **throws** when none is set — there is no default provider
+— and the throw is caught by the fail-soft path below.
+
+**Model** — per provider, not global: `resolveExtractModel` /
+`resolveSemanticCheckModel` read `TWING_<PROVIDER>_EXTRACT_MODEL` /
+`TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL` and fall back to a
+provider-appropriate default (`google.gemma-4-31b` for Bedrock,
+`google/gemini-2.0-flash` for Vertex, `openai/gpt-4o-mini` for
+OpenRouter/Bifrost). A single top-level model id was dropped in PR #11
+review — the same model has different ids on different providers, so it
+couldn't survive a provider switch.
 
 Schema-validated by hand on the way out (matches `manifest.ts`'s existing manual-parse
 style — no new dependency); one retry on malformed JSON. Unlike

--- a/docs/orchestrator-and-verification-design-doc_v1.md
+++ b/docs/orchestrator-and-verification-design-doc_v1.md
@@ -790,9 +790,12 @@ order:
 2. `GOOGLE_APPLICATION_CREDENTIALS` → GCP Vertex AI's OpenAI-compat
    endpoint. Auth is `google-auth-library`'s `GoogleAuth` (service-account
    JSON / gcloud ADC / GCE metadata server; it refreshes and caches the
-   token itself). `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` override
-   the project (else resolved from the credentials) and region (default
-   `us-central1`).
+   token itself). `GOOGLE_CLOUD_PROJECT` overrides the project (else
+   resolved from the credentials). `GOOGLE_CLOUD_LOCATION` defaults to
+   `global`, which — like an explicit `global` — uses the location-less
+   host `aiplatform.googleapis.com` (the request path still carries
+   `locations/global`); any regional value gets the `{location}-` DNS
+   prefix.
 3. `OPENROUTER_API_KEY` → OpenRouter (`OPENROUTER_BASE_URL` optional).
 4. `TWING_BIFROST_BASE_URL` → Bifrost gateway (optional `TWING_BIFROST_API_KEY`
    — an `sk-bf-*` value goes as the `x-bf-vk` header, anything else as

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,15 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "license": "MIT",
@@ -984,6 +993,15 @@
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bindings": {
@@ -1040,6 +1058,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1052,6 +1076,23 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -1227,6 +1268,15 @@
         }
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1287,6 +1337,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1314,6 +1370,36 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.2.tgz",
@@ -1333,11 +1419,63 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/hono": {
       "version": "4.13.1",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ieee754": {
@@ -1371,6 +1509,48 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -1412,6 +1592,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1435,6 +1621,26 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -1674,6 +1880,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tree-sitter-javascript": {
       "version": "0.25.0",
@@ -2265,9 +2477,39 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/web-tree-sitter": {
       "version": "0.26.12",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -2321,6 +2563,7 @@
         "@twing/core": "*",
         "better-sqlite3": "^11.10.0",
         "drizzle-orm": "^0.44.6",
+        "google-auth-library": "^9.15.1",
         "hono": "^4.13.1",
         "minimatch": "^10.0.1"
       },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
     "@twing/core": "*",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.44.6",
+    "google-auth-library": "^9.15.1",
     "hono": "^4.13.1",
     "minimatch": "^10.0.1"
   },

--- a/packages/server/scripts/run-semantic-eval.mjs
+++ b/packages/server/scripts/run-semantic-eval.mjs
@@ -2,10 +2,12 @@
 // Live-network regression run of design-semantic-check.ts's comparator
 // against the full labeled eval set (design-eval-cases.ts). NOT part of
 // `npm test` (same reasoning as simulator/ needing real credentials) --
-// this hits Bedrock for real, once per (candidate, openDesigns[i]) pair.
+// this hits whichever LLM provider llm-client.ts auto-detects, once per
+// (candidate, openDesigns[i]) pair.
 //
 // Usage:
 //   npm run build   # this imports from dist, not src
+//   # any provider llm-client.ts detects, e.g. Bedrock:
 //   AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION=us-east-1 node packages/server/scripts/run-semantic-eval.mjs
 //
 // Excludes the constraint_match category -- that's a deterministic
@@ -15,14 +17,17 @@
 
 import { checkSemanticConflict } from "../dist/design-semantic-check.js";
 import { EVAL_CASES } from "../dist/design-eval-cases.js";
+import { describeLlmProvider, resolveSemanticCheckModel } from "../dist/llm-client.js";
 
-const model = process.env.TWING_SEMANTIC_CHECK_MODEL ?? "google.gemma-4-31b";
-const region = process.env.AWS_REGION;
-
-if (!process.env.AWS_BEARER_TOKEN_BEDROCK) {
-  console.error("AWS_BEARER_TOKEN_BEDROCK not set -- this script needs real Bedrock credentials, exiting.");
+if (!describeLlmProvider().provider) {
+  console.error(
+    "no LLM provider configured -- set one of AWS_BEARER_TOKEN_BEDROCK / GOOGLE_APPLICATION_CREDENTIALS / OPENROUTER_API_KEY / TWING_BIFROST_BASE_URL, exiting.",
+  );
   process.exit(1);
 }
+
+const model = resolveSemanticCheckModel();
+const region = process.env.AWS_REGION;
 
 // Per-pair expected overrides where a case's single futureLlmExpectation
 // doesn't apply uniformly across multiple openDesigns entries.

--- a/packages/server/src/design-eval-cases.ts
+++ b/packages/server/src/design-eval-cases.ts
@@ -126,11 +126,11 @@ export interface EvalCase {
 
 export interface PlanModeProvenance {
   rawPlanText: string;
-  /** Hand-authored, honestly NOT live-verified -- no Bedrock credentials
-   * (see llm-client.ts) existed in this environment at the time. Regenerate
-   * for real via extractDesign(rawPlanText, {model, region}) once real
-   * credentials are available, and confirm the result isn't
-   * EMPTY_EXTRACTION before replacing this field. */
+  /** Hand-authored, honestly NOT live-verified -- no LLM provider
+   * (see llm-client.ts) was configured in this environment at the time.
+   * Regenerate for real via extractDesign(rawPlanText, { model:
+   * resolveExtractModel() }) once a provider is configured, and confirm the
+   * result isn't EMPTY_EXTRACTION before replacing this field. */
   simulatedExtraction: ExtractedDesign;
 }
 

--- a/packages/server/src/llm-client.test.ts
+++ b/packages/server/src/llm-client.test.ts
@@ -1,10 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { generateKeyPairSync } from "node:crypto";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { callLlm, callLlmMessages, describeLlmProvider, selectProvider } from "./llm-client.js";
+import {
+  callLlm,
+  callLlmMessages,
+  describeLlmProvider,
+  resolveExtractModel,
+  resolveSemanticCheckModel,
+  selectProvider,
+  __setVertexCredentialsForTests,
+  type VertexCredentials,
+} from "./llm-client.js";
 
 function withMockFetch<T>(impl: typeof fetch, run: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
@@ -87,16 +92,16 @@ test("callLlm: unmapped model defaults to the plain /v1 path", async () => {
   assert.equal(capturedUrl, "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions");
 });
 
-test("callLlm: no AWS_BEARER_TOKEN_BEDROCK set throws before any network call", async () => {
+test("callLlm: no AWS_BEARER_TOKEN_BEDROCK (and no other provider) throws before any network call", async () => {
   let called = false;
-  await withBedrockToken(undefined, () =>
+  await withEnv({}, () =>
     withMockFetch(
       (async () => {
         called = true;
         throw new Error("should not be called");
       }) as typeof fetch,
       async () => {
-        await assert.rejects(() => callLlm("s", "u", { model: "m", region: "us-east-1" }), /no credentials/);
+        await assert.rejects(() => callLlm("s", "u", { model: "m", region: "us-east-1" }), /no LLM provider configured/);
       },
     ),
   );
@@ -140,23 +145,30 @@ test("callLlm: missing/unknown content resolves to empty string, not a throw", a
 });
 
 // ---------------------------------------------------------------------------
-// Multi-provider dispatch (design a4937c29): Bifrost / OpenRouter / Vertex
-// alongside the default Bedrock path above.
+// Multi-provider dispatch (design a4937c29, PR #11 review follow-up): auto-
+// detect among Bedrock / Vertex / OpenRouter / Bifrost, per-provider models.
 // ---------------------------------------------------------------------------
 
 const PROVIDER_ENV_KEYS = [
-  "TWING_LLM_PROVIDER",
   "AWS_BEARER_TOKEN_BEDROCK",
   "AWS_REGION",
   "AWS_DEFAULT_REGION",
-  "TWING_BIFROST_BASE_URL",
-  "TWING_BIFROST_API_KEY",
-  "OPENROUTER_API_KEY",
-  "OPENROUTER_BASE_URL",
   "GOOGLE_APPLICATION_CREDENTIALS",
   "GOOGLE_CLOUD_PROJECT",
   "GCLOUD_PROJECT",
   "GOOGLE_CLOUD_LOCATION",
+  "OPENROUTER_API_KEY",
+  "OPENROUTER_BASE_URL",
+  "TWING_BIFROST_BASE_URL",
+  "TWING_BIFROST_API_KEY",
+  "TWING_BEDROCK_EXTRACT_MODEL",
+  "TWING_BEDROCK_SEMANTIC_CHECK_MODEL",
+  "TWING_VERTEX_EXTRACT_MODEL",
+  "TWING_VERTEX_SEMANTIC_CHECK_MODEL",
+  "TWING_OPENROUTER_EXTRACT_MODEL",
+  "TWING_OPENROUTER_SEMANTIC_CHECK_MODEL",
+  "TWING_BIFROST_EXTRACT_MODEL",
+  "TWING_BIFROST_SEMANTIC_CHECK_MODEL",
 ] as const;
 
 /** Clears every provider-selecting env var, applies `vars`, runs, restores.
@@ -177,30 +189,69 @@ function withEnv<T>(vars: Partial<Record<(typeof PROVIDER_ENV_KEYS)[number], str
   });
 }
 
-test("selectProvider: explicit TWING_LLM_PROVIDER wins over any detected credentials", async () => {
-  await withEnv({ TWING_LLM_PROVIDER: "bifrost", AWS_BEARER_TOKEN_BEDROCK: "t", TWING_BIFROST_BASE_URL: "http://x" }, async () => {
-    assert.equal(selectProvider(), "bifrost");
-  });
-  await withEnv({ TWING_LLM_PROVIDER: "  VERTEX  ", OPENROUTER_API_KEY: "k" }, async () => {
-    assert.equal(selectProvider(), "vertex");
+/** Swaps in a fake Vertex credential source for the body of `run`. */
+function withVertexCreds<T>(creds: VertexCredentials, run: () => Promise<T>): Promise<T> {
+  __setVertexCredentialsForTests(creds);
+  return run().finally(() => __setVertexCredentialsForTests(undefined));
+}
+
+test("selectProvider: precedence is AWS -> GCP -> OpenRouter -> Bifrost", async () => {
+  await withEnv(
+    { AWS_BEARER_TOKEN_BEDROCK: "t", GOOGLE_APPLICATION_CREDENTIALS: "/sa.json", OPENROUTER_API_KEY: "k", TWING_BIFROST_BASE_URL: "http://x" },
+    async () => assert.equal(selectProvider(), "bedrock"),
+  );
+  await withEnv(
+    { GOOGLE_APPLICATION_CREDENTIALS: "/sa.json", OPENROUTER_API_KEY: "k", TWING_BIFROST_BASE_URL: "http://x" },
+    async () => assert.equal(selectProvider(), "vertex"),
+  );
+  await withEnv({ OPENROUTER_API_KEY: "k", TWING_BIFROST_BASE_URL: "http://x" }, async () =>
+    assert.equal(selectProvider(), "openrouter"),
+  );
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://x" }, async () => assert.equal(selectProvider(), "bifrost"));
+});
+
+test("selectProvider: throws when no provider credential/base-URL is set (no default)", async () => {
+  await withEnv({}, async () => {
+    assert.throws(() => selectProvider(), /no LLM provider configured/);
   });
 });
 
-test("selectProvider: auto-detect precedence is bedrock > bifrost > openrouter > vertex, bedrock as the fallback", async () => {
-  await withEnv({ AWS_BEARER_TOKEN_BEDROCK: "t", TWING_BIFROST_BASE_URL: "http://x", OPENROUTER_API_KEY: "k" }, async () => {
-    assert.equal(selectProvider(), "bedrock");
+test("callLlm: with no provider configured, throws before any network call (caller fails soft)", async () => {
+  let called = false;
+  await withEnv({}, () =>
+    withMockFetch(
+      (async () => {
+        called = true;
+        throw new Error("should not be called");
+      }) as typeof fetch,
+      async () => {
+        await assert.rejects(() => callLlm("s", "u", { model: "m" }), /no LLM provider configured/);
+      },
+    ),
+  );
+  assert.equal(called, false);
+});
+
+test("resolveExtractModel / resolveSemanticCheckModel: per-provider default, overridable per provider", async () => {
+  await withEnv({ AWS_BEARER_TOKEN_BEDROCK: "t" }, async () => {
+    assert.equal(resolveExtractModel(), "google.gemma-4-31b");
+    assert.equal(resolveSemanticCheckModel(), "google.gemma-4-31b");
   });
-  await withEnv({ TWING_BIFROST_BASE_URL: "http://x", OPENROUTER_API_KEY: "k" }, async () => {
-    assert.equal(selectProvider(), "bifrost");
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://x" }, async () => {
+    assert.equal(resolveExtractModel(), "openai/gpt-4o-mini");
   });
-  await withEnv({ OPENROUTER_API_KEY: "k", GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json" }, async () => {
-    assert.equal(selectProvider(), "openrouter");
+  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/sa.json" }, async () => {
+    assert.equal(resolveExtractModel(), "google/gemini-2.0-flash");
   });
-  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json" }, async () => {
-    assert.equal(selectProvider(), "vertex");
-  });
+  await withEnv(
+    { OPENROUTER_API_KEY: "k", TWING_OPENROUTER_EXTRACT_MODEL: "anthropic/claude-3-5-haiku", TWING_OPENROUTER_SEMANTIC_CHECK_MODEL: "openai/gpt-4o" },
+    async () => {
+      assert.equal(resolveExtractModel(), "anthropic/claude-3-5-haiku");
+      assert.equal(resolveSemanticCheckModel(), "openai/gpt-4o");
+    },
+  );
   await withEnv({}, async () => {
-    assert.equal(selectProvider(), "bedrock");
+    assert.throws(() => resolveExtractModel(), /no LLM provider configured/);
   });
 });
 
@@ -319,96 +370,114 @@ test("openrouter: OPENROUTER_BASE_URL override is honoured", async () => {
   assert.equal(capturedUrl, "https://proxy.internal/or/v1/chat/completions");
 });
 
-test("openrouter: no OPENROUTER_API_KEY throws before any network call", async () => {
-  let called = false;
-  await withEnv({ TWING_LLM_PROVIDER: "openrouter" }, () =>
-    withMockFetch(
-      (async () => {
-        called = true;
-        throw new Error("should not be called");
-      }) as typeof fetch,
-      async () => {
-        await assert.rejects(() => callLlm("s", "u", { model: "m" }), /no credentials/);
-      },
-    ),
-  );
-  assert.equal(called, false);
-});
+test("vertex: gets a token + project from google-auth-library, calls the OpenAI-compat endpoint with Bearer", async () => {
+  let projectCalls = 0;
+  let tokenCalls = 0;
+  const creds: VertexCredentials = {
+    accessToken: async () => {
+      tokenCalls++;
+      return "ya29.fake";
+    },
+    projectId: async () => {
+      projectCalls++;
+      return "proj-from-adc";
+    },
+  };
 
-test("vertex: mints an access token from the SA key via jwt-bearer, then calls the OpenAI-compat endpoint; token is cached", async () => {
-  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-  const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
-  const dir = mkdtempSync(join(tmpdir(), "twing-vertex-"));
-  const saPath = join(dir, "sa.json");
-  writeFileSync(saPath, JSON.stringify({ client_email: "svc@proj.iam.gserviceaccount.com", private_key: pem }));
-
-  let tokenExchangeCalls = 0;
-  let aiCalls = 0;
   let aiUrl = "";
   let aiAuth = "";
   let aiBody: unknown;
-  const impl = (async (url: string, init?: RequestInit) => {
-    if (url === "https://oauth2.googleapis.com/token") {
-      tokenExchangeCalls++;
-      const params = new URLSearchParams(init!.body as string);
-      assert.equal(params.get("grant_type"), "urn:ietf:params:oauth:grant-type:jwt-bearer");
-      assert.match(params.get("assertion") ?? "", /^[\w-]+\.[\w-]+\.[\w-]+$/);
-      return new Response(JSON.stringify({ access_token: "ya29.fake", expires_in: 3600 }), { status: 200 });
-    }
-    aiCalls++;
-    aiUrl = url;
-    aiAuth = (init!.headers as Record<string, string>).authorization;
-    aiBody = JSON.parse(init!.body as string);
-    return new Response(JSON.stringify({ choices: [{ message: { content: "  hi from vertex  " } }] }), { status: 200 });
-  }) as typeof fetch;
-
-  await withEnv(
-    { GOOGLE_APPLICATION_CREDENTIALS: saPath, GOOGLE_CLOUD_PROJECT: "proj", GOOGLE_CLOUD_LOCATION: "us-central1" },
-    () =>
-      withMockFetch(impl, async () => {
-        const a = await callLlm("s", "u", { model: "google/gemini-2.0-flash" });
-        const b = await callLlm("s", "u", { model: "google/gemini-2.0-flash" });
-        assert.equal(a, "hi from vertex");
-        assert.equal(b, "hi from vertex");
-      }),
+  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/sa.json" }, () =>
+    withVertexCreds(creds, () =>
+      withMockFetch(
+        (async (url: string, init?: RequestInit) => {
+          aiUrl = url;
+          aiAuth = (init!.headers as Record<string, string>).authorization;
+          aiBody = JSON.parse(init!.body as string);
+          return new Response(JSON.stringify({ choices: [{ message: { content: "  hi from vertex  " } }] }), { status: 200 });
+        }) as typeof fetch,
+        async () => {
+          const text = await callLlm("s", "u", { model: "google/gemini-2.0-flash" });
+          assert.equal(text, "hi from vertex");
+        },
+      ),
+    ),
   );
 
   assert.equal(
     aiUrl,
-    "https://us-central1-aiplatform.googleapis.com/v1/projects/proj/locations/us-central1/endpoints/openapi/chat/completions",
+    "https://us-central1-aiplatform.googleapis.com/v1/projects/proj-from-adc/locations/us-central1/endpoints/openapi/chat/completions",
   );
   assert.equal(aiAuth, "Bearer ya29.fake");
   assert.deepEqual((aiBody as { model: string }).model, "google/gemini-2.0-flash");
-  assert.equal(aiCalls, 2);
-  assert.equal(tokenExchangeCalls, 1, "access token should be cached across calls");
+  assert.equal(tokenCalls, 1);
+  assert.equal(projectCalls, 1);
 });
 
-test("vertex: no GOOGLE_APPLICATION_CREDENTIALS throws before any network call", async () => {
-  let called = false;
-  await withEnv({ TWING_LLM_PROVIDER: "vertex", GOOGLE_CLOUD_PROJECT: "proj" }, () =>
-    withMockFetch(
-      (async () => {
-        called = true;
-        throw new Error("should not be called");
-      }) as typeof fetch,
-      async () => {
-        await assert.rejects(() => callLlm("s", "u", { model: "m" }), /no credentials/);
-      },
+test("vertex: GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION override the auto-resolved project + region", async () => {
+  let projectCalls = 0;
+  const creds: VertexCredentials = {
+    accessToken: async () => "ya29.fake",
+    projectId: async () => {
+      projectCalls++;
+      return "should-not-be-used";
+    },
+  };
+  let aiUrl = "";
+  await withEnv(
+    { GOOGLE_APPLICATION_CREDENTIALS: "/sa.json", GOOGLE_CLOUD_PROJECT: "explicit-proj", GOOGLE_CLOUD_LOCATION: "europe-west4" },
+    () =>
+      withVertexCreds(creds, () =>
+        withMockFetch(
+          (async (url: string) => {
+            aiUrl = url;
+            return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+          }) as typeof fetch,
+          () => callLlm("s", "u", { model: "google/gemini-2.0-flash" }),
+        ),
+      ),
+  );
+  assert.equal(
+    aiUrl,
+    "https://europe-west4-aiplatform.googleapis.com/v1/projects/explicit-proj/locations/europe-west4/endpoints/openapi/chat/completions",
+  );
+  assert.equal(projectCalls, 0, "explicit GOOGLE_CLOUD_PROJECT should short-circuit the credential lookup");
+});
+
+test("vertex: a credential error propagates (caller's retry loop is responsible for failing soft)", async () => {
+  const creds: VertexCredentials = {
+    accessToken: async () => {
+      throw new Error("google-auth-library returned no access token");
+    },
+    projectId: async () => "proj",
+  };
+  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/sa.json" }, () =>
+    withVertexCreds(creds, () =>
+      withMockFetch(
+        (async () => new Response("{}", { status: 200 })) as typeof fetch,
+        async () => {
+          await assert.rejects(() => callLlm("s", "u", { model: "m" }), /no access token/);
+        },
+      ),
     ),
   );
-  assert.equal(called, false);
 });
 
-test("describeLlmProvider: reports the active provider and whether it looks configured", async () => {
+test("describeLlmProvider: null when nothing is configured, otherwise the detected provider", async () => {
+  await withEnv({}, async () => {
+    const d = describeLlmProvider();
+    assert.equal(d.provider, null);
+    assert.equal(d.ready, false);
+  });
   await withEnv({ TWING_BIFROST_BASE_URL: "http://localhost:8080", TWING_BIFROST_API_KEY: "sk-bf-x" }, async () => {
     const d = describeLlmProvider();
     assert.equal(d.provider, "bifrost");
     assert.equal(d.ready, true);
     assert.match(d.summary, /virtual key/);
   });
-  await withEnv({ TWING_LLM_PROVIDER: "vertex" }, async () => {
+  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/sa.json" }, async () => {
     const d = describeLlmProvider();
     assert.equal(d.provider, "vertex");
-    assert.equal(d.ready, false);
+    assert.equal(d.ready, true);
   });
 });

--- a/packages/server/src/llm-client.test.ts
+++ b/packages/server/src/llm-client.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { callLlm, callLlmMessages } from "./llm-client.js";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { callLlm, callLlmMessages, describeLlmProvider, selectProvider } from "./llm-client.js";
 
 function withMockFetch<T>(impl: typeof fetch, run: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
@@ -133,4 +137,278 @@ test("callLlm: missing/unknown content resolves to empty string, not a throw", a
     ),
   );
   assert.equal(text, "");
+});
+
+// ---------------------------------------------------------------------------
+// Multi-provider dispatch (design a4937c29): Bifrost / OpenRouter / Vertex
+// alongside the default Bedrock path above.
+// ---------------------------------------------------------------------------
+
+const PROVIDER_ENV_KEYS = [
+  "TWING_LLM_PROVIDER",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "TWING_BIFROST_BASE_URL",
+  "TWING_BIFROST_API_KEY",
+  "OPENROUTER_API_KEY",
+  "OPENROUTER_BASE_URL",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_CLOUD_PROJECT",
+  "GCLOUD_PROJECT",
+  "GOOGLE_CLOUD_LOCATION",
+] as const;
+
+/** Clears every provider-selecting env var, applies `vars`, runs, restores.
+ * Keeps `selectProvider`'s auto-detection deterministic regardless of what
+ * the surrounding shell exported. */
+function withEnv<T>(vars: Partial<Record<(typeof PROVIDER_ENV_KEYS)[number], string>>, run: () => Promise<T>): Promise<T> {
+  const saved = new Map<string, string | undefined>();
+  for (const k of PROVIDER_ENV_KEYS) {
+    saved.set(k, process.env[k]);
+    delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(vars)) process.env[k] = v;
+  return run().finally(() => {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+}
+
+test("selectProvider: explicit TWING_LLM_PROVIDER wins over any detected credentials", async () => {
+  await withEnv({ TWING_LLM_PROVIDER: "bifrost", AWS_BEARER_TOKEN_BEDROCK: "t", TWING_BIFROST_BASE_URL: "http://x" }, async () => {
+    assert.equal(selectProvider(), "bifrost");
+  });
+  await withEnv({ TWING_LLM_PROVIDER: "  VERTEX  ", OPENROUTER_API_KEY: "k" }, async () => {
+    assert.equal(selectProvider(), "vertex");
+  });
+});
+
+test("selectProvider: auto-detect precedence is bedrock > bifrost > openrouter > vertex, bedrock as the fallback", async () => {
+  await withEnv({ AWS_BEARER_TOKEN_BEDROCK: "t", TWING_BIFROST_BASE_URL: "http://x", OPENROUTER_API_KEY: "k" }, async () => {
+    assert.equal(selectProvider(), "bedrock");
+  });
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://x", OPENROUTER_API_KEY: "k" }, async () => {
+    assert.equal(selectProvider(), "bifrost");
+  });
+  await withEnv({ OPENROUTER_API_KEY: "k", GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json" }, async () => {
+    assert.equal(selectProvider(), "openrouter");
+  });
+  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json" }, async () => {
+    assert.equal(selectProvider(), "vertex");
+  });
+  await withEnv({}, async () => {
+    assert.equal(selectProvider(), "bedrock");
+  });
+});
+
+test("bifrost: POST {base}/v1/chat/completions, {model,messages} body, trimmed content, no auth header when keyless", async () => {
+  let capturedUrl = "";
+  let capturedHeaders: Record<string, string> = {};
+  let capturedBody: unknown;
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://localhost:8080" }, () =>
+    withMockFetch(
+      (async (url: string, init?: RequestInit) => {
+        capturedUrl = url;
+        capturedHeaders = init!.headers as Record<string, string>;
+        capturedBody = JSON.parse(init!.body as string);
+        return new Response(JSON.stringify({ choices: [{ message: { content: "  hi from bifrost  " } }] }), { status: 200 });
+      }) as typeof fetch,
+      async () => {
+        const text = await callLlm("sys", "usr", { model: "openai/gpt-4o-mini" });
+        assert.equal(text, "hi from bifrost");
+      },
+    ),
+  );
+  assert.equal(capturedUrl, "http://localhost:8080/v1/chat/completions");
+  assert.equal(capturedHeaders.authorization, undefined);
+  assert.equal(capturedHeaders["x-bf-vk"], undefined);
+  assert.deepEqual(capturedBody, {
+    model: "openai/gpt-4o-mini",
+    messages: [
+      { role: "system", content: "sys" },
+      { role: "user", content: "usr" },
+    ],
+  });
+});
+
+test("bifrost: trailing slash on TWING_BIFROST_BASE_URL is normalised", async () => {
+  let capturedUrl = "";
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://localhost:8080/" }, () =>
+    withMockFetch(
+      (async (url: string) => {
+        capturedUrl = url;
+        return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+      }) as typeof fetch,
+      () => callLlm("s", "u", { model: "m" }),
+    ),
+  );
+  assert.equal(capturedUrl, "http://localhost:8080/v1/chat/completions");
+});
+
+test("bifrost: a sk-bf- key goes as x-bf-vk, anything else as Authorization: Bearer", async () => {
+  let headers: Record<string, string> = {};
+  const capture = (async (_url: string, init?: RequestInit) => {
+    headers = init!.headers as Record<string, string>;
+    return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+  }) as typeof fetch;
+
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://x", TWING_BIFROST_API_KEY: "sk-bf-abc123" }, () =>
+    withMockFetch(capture, () => callLlm("s", "u", { model: "m" })),
+  );
+  assert.equal(headers["x-bf-vk"], "sk-bf-abc123");
+  assert.equal(headers.authorization, undefined);
+
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://x", TWING_BIFROST_API_KEY: "sk-live-xyz" }, () =>
+    withMockFetch(capture, () => callLlm("s", "u", { model: "m" })),
+  );
+  assert.equal(headers.authorization, "Bearer sk-live-xyz");
+  assert.equal(headers["x-bf-vk"], undefined);
+});
+
+test("bifrost: non-ok response throws with the error message", async () => {
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://x" }, () =>
+    withMockFetch(
+      (async () => new Response(JSON.stringify({ error: { message: "model not found" } }), { status: 500 })) as typeof fetch,
+      async () => {
+        await assert.rejects(() => callLlm("s", "u", { model: "m" }), /Bifrost request failed \(500\): model not found/);
+      },
+    ),
+  );
+});
+
+test("openrouter: routes to openrouter.ai with Bearer OPENROUTER_API_KEY and passes the full message list", async () => {
+  let capturedUrl = "";
+  let capturedAuth = "";
+  let capturedBody: unknown;
+  const messages = [
+    { role: "system" as const, content: "sys" },
+    { role: "user" as const, content: "a" },
+    { role: "assistant" as const, content: "b" },
+    { role: "user" as const, content: "c" },
+  ];
+  await withEnv({ OPENROUTER_API_KEY: "or-key" }, () =>
+    withMockFetch(
+      (async (url: string, init?: RequestInit) => {
+        capturedUrl = url;
+        capturedAuth = (init!.headers as Record<string, string>).authorization;
+        capturedBody = JSON.parse(init!.body as string);
+        return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+      }) as typeof fetch,
+      () => callLlmMessages(messages, { model: "openai/gpt-4o-mini" }),
+    ),
+  );
+  assert.equal(capturedUrl, "https://openrouter.ai/api/v1/chat/completions");
+  assert.equal(capturedAuth, "Bearer or-key");
+  assert.deepEqual((capturedBody as { messages: unknown }).messages, messages);
+});
+
+test("openrouter: OPENROUTER_BASE_URL override is honoured", async () => {
+  let capturedUrl = "";
+  await withEnv({ OPENROUTER_API_KEY: "k", OPENROUTER_BASE_URL: "https://proxy.internal/or/v1/" }, () =>
+    withMockFetch(
+      (async (url: string) => {
+        capturedUrl = url;
+        return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+      }) as typeof fetch,
+      () => callLlm("s", "u", { model: "m" }),
+    ),
+  );
+  assert.equal(capturedUrl, "https://proxy.internal/or/v1/chat/completions");
+});
+
+test("openrouter: no OPENROUTER_API_KEY throws before any network call", async () => {
+  let called = false;
+  await withEnv({ TWING_LLM_PROVIDER: "openrouter" }, () =>
+    withMockFetch(
+      (async () => {
+        called = true;
+        throw new Error("should not be called");
+      }) as typeof fetch,
+      async () => {
+        await assert.rejects(() => callLlm("s", "u", { model: "m" }), /no credentials/);
+      },
+    ),
+  );
+  assert.equal(called, false);
+});
+
+test("vertex: mints an access token from the SA key via jwt-bearer, then calls the OpenAI-compat endpoint; token is cached", async () => {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  const dir = mkdtempSync(join(tmpdir(), "twing-vertex-"));
+  const saPath = join(dir, "sa.json");
+  writeFileSync(saPath, JSON.stringify({ client_email: "svc@proj.iam.gserviceaccount.com", private_key: pem }));
+
+  let tokenExchangeCalls = 0;
+  let aiCalls = 0;
+  let aiUrl = "";
+  let aiAuth = "";
+  let aiBody: unknown;
+  const impl = (async (url: string, init?: RequestInit) => {
+    if (url === "https://oauth2.googleapis.com/token") {
+      tokenExchangeCalls++;
+      const params = new URLSearchParams(init!.body as string);
+      assert.equal(params.get("grant_type"), "urn:ietf:params:oauth:grant-type:jwt-bearer");
+      assert.match(params.get("assertion") ?? "", /^[\w-]+\.[\w-]+\.[\w-]+$/);
+      return new Response(JSON.stringify({ access_token: "ya29.fake", expires_in: 3600 }), { status: 200 });
+    }
+    aiCalls++;
+    aiUrl = url;
+    aiAuth = (init!.headers as Record<string, string>).authorization;
+    aiBody = JSON.parse(init!.body as string);
+    return new Response(JSON.stringify({ choices: [{ message: { content: "  hi from vertex  " } }] }), { status: 200 });
+  }) as typeof fetch;
+
+  await withEnv(
+    { GOOGLE_APPLICATION_CREDENTIALS: saPath, GOOGLE_CLOUD_PROJECT: "proj", GOOGLE_CLOUD_LOCATION: "us-central1" },
+    () =>
+      withMockFetch(impl, async () => {
+        const a = await callLlm("s", "u", { model: "google/gemini-2.0-flash" });
+        const b = await callLlm("s", "u", { model: "google/gemini-2.0-flash" });
+        assert.equal(a, "hi from vertex");
+        assert.equal(b, "hi from vertex");
+      }),
+  );
+
+  assert.equal(
+    aiUrl,
+    "https://us-central1-aiplatform.googleapis.com/v1/projects/proj/locations/us-central1/endpoints/openapi/chat/completions",
+  );
+  assert.equal(aiAuth, "Bearer ya29.fake");
+  assert.deepEqual((aiBody as { model: string }).model, "google/gemini-2.0-flash");
+  assert.equal(aiCalls, 2);
+  assert.equal(tokenExchangeCalls, 1, "access token should be cached across calls");
+});
+
+test("vertex: no GOOGLE_APPLICATION_CREDENTIALS throws before any network call", async () => {
+  let called = false;
+  await withEnv({ TWING_LLM_PROVIDER: "vertex", GOOGLE_CLOUD_PROJECT: "proj" }, () =>
+    withMockFetch(
+      (async () => {
+        called = true;
+        throw new Error("should not be called");
+      }) as typeof fetch,
+      async () => {
+        await assert.rejects(() => callLlm("s", "u", { model: "m" }), /no credentials/);
+      },
+    ),
+  );
+  assert.equal(called, false);
+});
+
+test("describeLlmProvider: reports the active provider and whether it looks configured", async () => {
+  await withEnv({ TWING_BIFROST_BASE_URL: "http://localhost:8080", TWING_BIFROST_API_KEY: "sk-bf-x" }, async () => {
+    const d = describeLlmProvider();
+    assert.equal(d.provider, "bifrost");
+    assert.equal(d.ready, true);
+    assert.match(d.summary, /virtual key/);
+  });
+  await withEnv({ TWING_LLM_PROVIDER: "vertex" }, async () => {
+    const d = describeLlmProvider();
+    assert.equal(d.provider, "vertex");
+    assert.equal(d.ready, false);
+  });
 });

--- a/packages/server/src/llm-client.test.ts
+++ b/packages/server/src/llm-client.test.ts
@@ -404,14 +404,36 @@ test("vertex: gets a token + project from google-auth-library, calls the OpenAI-
     ),
   );
 
+  // No GOOGLE_CLOUD_LOCATION -> defaults to "global" -> location-less host,
+  // path still carries locations/global.
   assert.equal(
     aiUrl,
-    "https://us-central1-aiplatform.googleapis.com/v1/projects/proj-from-adc/locations/us-central1/endpoints/openapi/chat/completions",
+    "https://aiplatform.googleapis.com/v1/projects/proj-from-adc/locations/global/endpoints/openapi/chat/completions",
   );
   assert.equal(aiAuth, "Bearer ya29.fake");
   assert.deepEqual((aiBody as { model: string }).model, "google/gemini-2.0-flash");
   assert.equal(tokenCalls, 1);
   assert.equal(projectCalls, 1);
+});
+
+test("vertex: an explicit GOOGLE_CLOUD_LOCATION=global also uses the location-less host", async () => {
+  const creds: VertexCredentials = { accessToken: async () => "ya29.fake", projectId: async () => "p" };
+  let aiUrl = "";
+  await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/sa.json", GOOGLE_CLOUD_PROJECT: "proj", GOOGLE_CLOUD_LOCATION: "global" }, () =>
+    withVertexCreds(creds, () =>
+      withMockFetch(
+        (async (url: string) => {
+          aiUrl = url;
+          return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+        }) as typeof fetch,
+        () => callLlm("s", "u", { model: "google/gemini-2.0-flash" }),
+      ),
+    ),
+  );
+  assert.equal(
+    aiUrl,
+    "https://aiplatform.googleapis.com/v1/projects/proj/locations/global/endpoints/openapi/chat/completions",
+  );
 });
 
 test("vertex: GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION override the auto-resolved project + region", async () => {

--- a/packages/server/src/llm-client.ts
+++ b/packages/server/src/llm-client.ts
@@ -4,31 +4,62 @@
  * serve `design-semantic-check.ts`'s async comparator, which needs real
  * few-shot conversation turns (system + example user/assistant pairs + the
  * real user turn), not just a single system+user exchange. This module owns
- * the Bedrock call only; retry policy, parsing, and fail-soft behavior stay
+ * the model call only; retry policy, parsing, and fail-soft behavior stay
  * in whichever caller has an opinion about them -- this file doesn't catch
  * its own errors, it throws on failure.
  *
- * Bedrock-only (OpenRouter support removed 2026-08-17 -- see git history if
- * it's ever needed again; the org standardized on AWS Bedrock and doesn't
- * want a second LLM vendor in the loop at all). Talks to `bedrock-mantle`,
- * an OpenAI-compatible chat-completions shim -- *not* the standard Bedrock
- * Runtime `Converse` API. That SDK path doesn't actually work for the
- * models this system uses on the account we have credits on:
- * `google.gemma-4-31b` isn't in `ListFoundationModels`' catalog at all, and
- * `zai.glm-5` (which is listed) returns "Operation not allowed" on
- * `ConverseCommand` -- both are only reachable through this separate shim,
- * confirmed live (2026-08). Since bedrock-mantle is a plain Bearer-token
- * HTTPS API, there's no AWS SigV4/SDK involved at all.
- * Per-model path differs (`gemma-4-31b` needs `/openai/v1`, everything else
- * defaults to plain `/v1`) -- same pattern as TwingMail's own
- * `packages/core/src/lib/ai.ts` `BEDROCK_MODEL_MAP`, which solves this
- * exact routing problem for its own Gemma usage.
+ * Four provider paths, all speaking the same OpenAI chat-completions
+ * request/response shape so `parseChatCompletion` is shared and the caller
+ * (`callLlmMessages`) only picks a transport (OpenRouter was a fifth once,
+ * removed 2026-08-17, then folded back in here 2026-08-30 alongside Bifrost
+ * and Vertex -- see design a4937c29):
  *
- * Credentials are read ambiently from the environment
- * (`AWS_BEARER_TOKEN_BEDROCK` for auth, `region` falling back to
- * `AWS_REGION`/`AWS_DEFAULT_REGION` when unset) -- there's no explicit
- * caller-supplied secret the way an API key would be.
+ *   - bedrock     `bedrock-mantle`, the default. Plain Bearer-token HTTPS
+ *                 shim, *not* the Bedrock Runtime `Converse` API (that SDK
+ *                 path doesn't work for the models on the account we have
+ *                 credits on: `google.gemma-4-31b` isn't in
+ *                 `ListFoundationModels` at all, `zai.glm-5` returns
+ *                 "Operation not allowed" on `ConverseCommand` -- both are
+ *                 only reachable through this shim, confirmed live 2026-08).
+ *                 Per-model path differs (`gemma-4-31b` -> `/openai/v1`,
+ *                 everything else -> `/v1`), same pattern as TwingMail's own
+ *                 `packages/core/src/lib/ai.ts` `BEDROCK_MODEL_MAP`.
+ *   - bifrost     A self-hosted LLM gateway (https://docs.getbifrost.ai).
+ *                 OpenAI-shaped `POST {base}/v1/chat/completions`; `model`
+ *                 is a `provider/model` string (e.g. `openai/gpt-4o-mini`).
+ *   - openrouter  `https://openrouter.ai/api/v1/chat/completions`; `model`
+ *                 is a `provider/model` string.
+ *   - vertex      GCP Vertex AI's OpenAI-compatible endpoint. Auth is a
+ *                 short-lived OAuth token minted from a service-account JSON
+ *                 via an RS256 JWT bearer grant -- done here with `node:crypto`
+ *                 rather than pulling in `google-auth-library`, matching this
+ *                 module's no-SDK stance (same reason `callBedrock` hand-rolls
+ *                 its Bearer call instead of using the AWS SDK). Token cached
+ *                 in-process until ~1min before expiry.
+ *
+ * Provider selection is ambient -- there is no caller-supplied `provider`
+ * field, same way credentials are read from `process.env` rather than
+ * threaded through `LlmCallOptions`. `TWING_LLM_PROVIDER` forces the choice
+ * when set to a known value; otherwise `selectProvider` auto-detects from
+ * which credential/base-URL vars are present, Bedrock winning ties (the
+ * assumption is only one provider's config is present at a time and Bedrock
+ * is the default). A misconfigured deployment finds out when the real call
+ * throws and the caller falls soft -- there is no separate presence
+ * precheck here (main.ts logs one advisory line at startup, that's all).
+ *
+ * Env, by provider:
+ *   bedrock     AWS_BEARER_TOKEN_BEDROCK, AWS_REGION / AWS_DEFAULT_REGION
+ *   bifrost     TWING_BIFROST_BASE_URL, TWING_BIFROST_API_KEY (optional;
+ *               unset -> no auth header, `sk-bf-` prefix -> `x-bf-vk`
+ *               header, anything else -> `Authorization: Bearer <key>`)
+ *   openrouter  OPENROUTER_API_KEY, OPENROUTER_BASE_URL (optional)
+ *   vertex      GOOGLE_APPLICATION_CREDENTIALS (service-account JSON path),
+ *               GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT,
+ *               GOOGLE_CLOUD_LOCATION (optional, default us-central1)
  */
+
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
 
 // gemma-4-31b is only reachable via bedrock-mantle's OpenAI-compat route,
 // not its plain-Bedrock-model route -- everything else (glm-5, and per
@@ -43,10 +74,90 @@ export interface ChatMessage {
 }
 
 export interface LlmCallOptions {
-  /** Bedrock model id -- e.g. "google.gemma-4-31b", "zai.glm-5". */
+  /** Model id, in whatever form the selected provider expects -- a
+   * Bedrock model id (`google.gemma-4-31b`), or a `provider/model` string
+   * for Bifrost/OpenRouter/Vertex (`openai/gpt-4o-mini`,
+   * `google/gemini-2.0-flash`). */
   model: string;
-  /** Omit to fall back to AWS_REGION/AWS_DEFAULT_REGION. */
+  /** Bedrock only: omit to fall back to AWS_REGION/AWS_DEFAULT_REGION. */
   region?: string;
+}
+
+export type LlmProvider = "bedrock" | "bifrost" | "openrouter" | "vertex";
+
+const KNOWN_PROVIDERS: readonly LlmProvider[] = ["bedrock", "bifrost", "openrouter", "vertex"];
+
+/**
+ * Which provider a call will use right now, given the environment. An
+ * explicit `TWING_LLM_PROVIDER` wins; otherwise the first provider whose
+ * config is present, in precedence order, with Bedrock as the final
+ * fallback (so a fully unconfigured server still throws "no credentials"
+ * from `callBedrock` and the caller fails soft, unchanged behavior).
+ */
+export function selectProvider(): LlmProvider {
+  const explicit = process.env.TWING_LLM_PROVIDER?.trim().toLowerCase();
+  if (explicit && (KNOWN_PROVIDERS as readonly string[]).includes(explicit)) {
+    return explicit as LlmProvider;
+  }
+  if (process.env.AWS_BEARER_TOKEN_BEDROCK) return "bedrock";
+  if (process.env.TWING_BIFROST_BASE_URL) return "bifrost";
+  if (process.env.OPENROUTER_API_KEY) return "openrouter";
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) return "vertex";
+  return "bedrock";
+}
+
+/** One-line, secret-free description of the active provider config, for
+ * main.ts's startup log. `ready` is a best-effort "the obvious required
+ * vars are present" check -- not a live call. */
+export function describeLlmProvider(): { provider: LlmProvider; ready: boolean; summary: string } {
+  const provider = selectProvider();
+  switch (provider) {
+    case "bedrock": {
+      const region = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
+      const ready = Boolean(process.env.AWS_BEARER_TOKEN_BEDROCK && region);
+      return {
+        provider,
+        ready,
+        summary: `Bedrock (bedrock-mantle)${region ? `, region ${region}` : ", region unset"}`,
+      };
+    }
+    case "bifrost": {
+      const base = process.env.TWING_BIFROST_BASE_URL;
+      const key = process.env.TWING_BIFROST_API_KEY;
+      const auth = !key ? "no auth" : key.startsWith("sk-bf-") ? "virtual key" : "bearer token";
+      return { provider, ready: Boolean(base), summary: `Bifrost gateway at ${base ?? "(TWING_BIFROST_BASE_URL unset)"} (${auth})` };
+    }
+    case "openrouter":
+      return {
+        provider,
+        ready: Boolean(process.env.OPENROUTER_API_KEY),
+        summary: `OpenRouter at ${process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1"}`,
+      };
+    case "vertex": {
+      const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
+      const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
+      const ready = Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS && project);
+      return {
+        provider,
+        ready,
+        summary: `Vertex AI (project ${project ?? "unset"}, location ${location})`,
+      };
+    }
+  }
+}
+
+/** Shared for all four transports: they all return
+ * `{ choices: [{ message: { content } }] }` on success and
+ * `{ error: { message } }` on failure. */
+async function parseChatCompletion(res: Response, label: string): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as {
+    choices?: { message?: { content?: string } }[];
+    error?: { message?: string };
+  };
+  if (!res.ok) {
+    throw new Error(`${label} request failed (${res.status}): ${body.error?.message ?? JSON.stringify(body)}`);
+  }
+  return body.choices?.[0]?.message?.content?.trim() ?? "";
 }
 
 async function callBedrock(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
@@ -65,20 +176,163 @@ async function callBedrock(messages: ChatMessage[], options: LlmCallOptions): Pr
     headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
     body: JSON.stringify({ model: options.model, messages }),
   });
+  return parseChatCompletion(res, "Bedrock");
+}
 
-  const body = (await res.json()) as { choices?: { message?: { content?: string } }[]; error?: { message?: string } };
-  if (!res.ok) {
-    throw new Error(`Bedrock request failed (${res.status}): ${body.error?.message ?? JSON.stringify(body)}`);
+/** `sk-bf-...` -> Bifrost virtual key header; any other value -> bearer;
+ * unset -> no auth header at all (a keyless localhost gateway). */
+function bifrostAuthHeaders(key: string | undefined): Record<string, string> {
+  if (!key) return {};
+  if (key.startsWith("sk-bf-")) return { "x-bf-vk": key };
+  return { authorization: `Bearer ${key}` };
+}
+
+async function callBifrost(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
+  const rawBase = process.env.TWING_BIFROST_BASE_URL;
+  if (!rawBase) {
+    throw new Error("Bifrost request failed: no gateway URL -- set TWING_BIFROST_BASE_URL");
   }
-  return body.choices?.[0]?.message?.content?.trim() ?? "";
+  const base = rawBase.replace(/\/+$/, "");
+
+  const res = await fetch(`${base}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bifrostAuthHeaders(process.env.TWING_BIFROST_API_KEY) },
+    body: JSON.stringify({ model: options.model, messages }),
+  });
+  return parseChatCompletion(res, "Bifrost");
+}
+
+async function callOpenRouter(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key) {
+    throw new Error("OpenRouter request failed: no credentials -- set OPENROUTER_API_KEY");
+  }
+  const base = (process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1").replace(/\/+$/, "");
+
+  const res = await fetch(`${base}/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${key}` },
+    body: JSON.stringify({ model: options.model, messages }),
+  });
+  return parseChatCompletion(res, "OpenRouter");
+}
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+let vertexTokenCache: { key: string; token: string; expiresAt: number } | null = null;
+
+function base64url(input: string | Buffer): string {
+  return (typeof input === "string" ? Buffer.from(input) : input).toString("base64url");
+}
+
+/** Mint (and cache) a cloud-platform access token from a service-account
+ * key via the RS256 JWT bearer grant -- no `google-auth-library`. Cached
+ * per `client_email` until ~1min before the token's own expiry. */
+async function vertexAccessToken(sa: ServiceAccountKey): Promise<string> {
+  const now = Date.now();
+  if (vertexTokenCache && vertexTokenCache.key === sa.client_email && vertexTokenCache.expiresAt > now + 60_000) {
+    return vertexTokenCache.token;
+  }
+  const tokenUri = sa.token_uri ?? "https://oauth2.googleapis.com/token";
+  const iat = Math.floor(now / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64url(
+    JSON.stringify({
+      iss: sa.client_email,
+      scope: "https://www.googleapis.com/auth/cloud-platform",
+      aud: tokenUri,
+      iat,
+      exp: iat + 3600,
+    }),
+  );
+  const signingInput = `${header}.${claims}`;
+  const signature = base64url(createSign("RSA-SHA256").update(signingInput).sign(sa.private_key));
+  const assertion = `${signingInput}.${signature}`;
+
+  const res = await fetch(tokenUri, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  const body = (await res.json().catch(() => ({}))) as {
+    access_token?: string;
+    expires_in?: number;
+    error?: string;
+    error_description?: string;
+  };
+  if (!res.ok || !body.access_token) {
+    throw new Error(
+      `Vertex token exchange failed (${res.status}): ${body.error_description ?? body.error ?? JSON.stringify(body)}`,
+    );
+  }
+  vertexTokenCache = {
+    key: sa.client_email,
+    token: body.access_token,
+    expiresAt: now + (body.expires_in ?? 3600) * 1000,
+  };
+  return body.access_token;
+}
+
+async function callVertex(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credPath) {
+    throw new Error(
+      "Vertex request failed: no credentials -- set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON path",
+    );
+  }
+  const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
+  if (!project) {
+    throw new Error("Vertex request failed: no project -- set GOOGLE_CLOUD_PROJECT");
+  }
+  const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
+
+  let sa: ServiceAccountKey;
+  try {
+    sa = JSON.parse(await readFile(credPath, "utf8")) as ServiceAccountKey;
+  } catch (err) {
+    throw new Error(
+      `Vertex request failed: could not read GOOGLE_APPLICATION_CREDENTIALS (${credPath}): ${err instanceof Error ? err.message : err}`,
+    );
+  }
+  if (!sa.client_email || !sa.private_key) {
+    throw new Error("Vertex request failed: GOOGLE_APPLICATION_CREDENTIALS is not a service-account key (no client_email/private_key)");
+  }
+  const token = await vertexAccessToken(sa);
+
+  const res = await fetch(
+    `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/endpoints/openapi/chat/completions`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ model: options.model, messages }),
+    },
+  );
+  return parseChatCompletion(res, "Vertex");
 }
 
 /** The general form: a full message list (system + any few-shot user/
  * assistant example turns + the real user turn). `callLlm` below is a thin
  * convenience wrapper for the common single-system-message-plus-user-turn
- * case. */
+ * case. Provider is chosen ambiently -- see `selectProvider`. */
 export async function callLlmMessages(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
-  return callBedrock(messages, options);
+  switch (selectProvider()) {
+    case "bifrost":
+      return callBifrost(messages, options);
+    case "openrouter":
+      return callOpenRouter(messages, options);
+    case "vertex":
+      return callVertex(messages, options);
+    case "bedrock":
+    default:
+      return callBedrock(messages, options);
+  }
 }
 
 export async function callLlm(systemPrompt: string, userPrompt: string, options: LlmCallOptions): Promise<string> {

--- a/packages/server/src/llm-client.ts
+++ b/packages/server/src/llm-client.ts
@@ -14,52 +14,65 @@
  * removed 2026-08-17, then folded back in here 2026-08-30 alongside Bifrost
  * and Vertex -- see design a4937c29):
  *
- *   - bedrock     `bedrock-mantle`, the default. Plain Bearer-token HTTPS
- *                 shim, *not* the Bedrock Runtime `Converse` API (that SDK
- *                 path doesn't work for the models on the account we have
- *                 credits on: `google.gemma-4-31b` isn't in
- *                 `ListFoundationModels` at all, `zai.glm-5` returns
- *                 "Operation not allowed" on `ConverseCommand` -- both are
- *                 only reachable through this shim, confirmed live 2026-08).
- *                 Per-model path differs (`gemma-4-31b` -> `/openai/v1`,
- *                 everything else -> `/v1`), same pattern as TwingMail's own
+ *   - bedrock     `bedrock-mantle`, a plain Bearer-token HTTPS shim, *not*
+ *                 the Bedrock Runtime `Converse` API (that SDK path doesn't
+ *                 work for the models on the account we have credits on:
+ *                 `google.gemma-4-31b` isn't in `ListFoundationModels` at
+ *                 all, `zai.glm-5` returns "Operation not allowed" on
+ *                 `ConverseCommand` -- both are only reachable through this
+ *                 shim, confirmed live 2026-08). Per-model path differs
+ *                 (`gemma-4-31b` -> `/openai/v1`, everything else -> `/v1`),
+ *                 same pattern as TwingMail's own
  *                 `packages/core/src/lib/ai.ts` `BEDROCK_MODEL_MAP`.
+ *   - vertex      GCP Vertex AI's OpenAI-compatible endpoint. Auth is a
+ *                 short-lived OAuth token from `google-auth-library`'s
+ *                 `GoogleAuth` (picks up `GOOGLE_APPLICATION_CREDENTIALS` /
+ *                 ADC / the GCE metadata server, and handles token refresh
+ *                 and caching itself) -- the hand-rolled RS256-JWT bearer
+ *                 grant this used to do with `node:crypto` was more surface
+ *                 area than it was worth (PR #11 review).
+ *   - openrouter  `https://openrouter.ai/api/v1/chat/completions`; `model`
+ *                 is a `provider/model` string.
  *   - bifrost     A self-hosted LLM gateway (https://docs.getbifrost.ai).
  *                 OpenAI-shaped `POST {base}/v1/chat/completions`; `model`
  *                 is a `provider/model` string (e.g. `openai/gpt-4o-mini`).
- *   - openrouter  `https://openrouter.ai/api/v1/chat/completions`; `model`
- *                 is a `provider/model` string.
- *   - vertex      GCP Vertex AI's OpenAI-compatible endpoint. Auth is a
- *                 short-lived OAuth token minted from a service-account JSON
- *                 via an RS256 JWT bearer grant -- done here with `node:crypto`
- *                 rather than pulling in `google-auth-library`, matching this
- *                 module's no-SDK stance (same reason `callBedrock` hand-rolls
- *                 its Bearer call instead of using the AWS SDK). Token cached
- *                 in-process until ~1min before expiry.
  *
  * Provider selection is ambient -- there is no caller-supplied `provider`
- * field, same way credentials are read from `process.env` rather than
- * threaded through `LlmCallOptions`. `TWING_LLM_PROVIDER` forces the choice
- * when set to a known value; otherwise `selectProvider` auto-detects from
- * which credential/base-URL vars are present, Bedrock winning ties (the
- * assumption is only one provider's config is present at a time and Bedrock
- * is the default). A misconfigured deployment finds out when the real call
- * throws and the caller falls soft -- there is no separate presence
- * precheck here (main.ts logs one advisory line at startup, that's all).
+ * field and no `TWING_LLM_PROVIDER` override, same way credentials are read
+ * from `process.env` rather than threaded through `LlmCallOptions`.
+ * `selectProvider` picks the first provider whose credential/base-URL var
+ * is present, in precedence order **AWS -> GCP -> OpenRouter -> Bifrost**,
+ * and **throws** if none is set (there is no default). The throw propagates
+ * to the caller, whose retry loop (`design-extract.ts` /
+ * `design-semantic-check.ts`) catches it and fails soft -- extraction to
+ * empty fields ("clean"), the comparator to "no conflict". So a server with
+ * no LLM provider configured still runs; it just never blocks on a
+ * plan-text check. `main.ts` logs one advisory line at startup.
+ *
+ * Model is chosen per provider, not globally (PR #11 review: the same model
+ * has different ids on different providers, so a single top-level default
+ * can't survive a provider switch). `resolveExtractModel` /
+ * `resolveSemanticCheckModel` read `TWING_<PROVIDER>_EXTRACT_MODEL` /
+ * `TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL` and fall back to a
+ * provider-appropriate default (see `PROVIDER_MODELS`).
  *
  * Env, by provider:
- *   bedrock     AWS_BEARER_TOKEN_BEDROCK, AWS_REGION / AWS_DEFAULT_REGION
+ *   bedrock     AWS_BEARER_TOKEN_BEDROCK, AWS_REGION / AWS_DEFAULT_REGION,
+ *               TWING_BEDROCK_EXTRACT_MODEL / TWING_BEDROCK_SEMANTIC_CHECK_MODEL
+ *   vertex      GOOGLE_APPLICATION_CREDENTIALS (service-account JSON path;
+ *               also what selection keys off), GOOGLE_CLOUD_PROJECT /
+ *               GCLOUD_PROJECT (or resolved from the credentials),
+ *               GOOGLE_CLOUD_LOCATION (optional, default us-central1),
+ *               TWING_VERTEX_EXTRACT_MODEL / TWING_VERTEX_SEMANTIC_CHECK_MODEL
+ *   openrouter  OPENROUTER_API_KEY, OPENROUTER_BASE_URL (optional),
+ *               TWING_OPENROUTER_EXTRACT_MODEL / TWING_OPENROUTER_SEMANTIC_CHECK_MODEL
  *   bifrost     TWING_BIFROST_BASE_URL, TWING_BIFROST_API_KEY (optional;
  *               unset -> no auth header, `sk-bf-` prefix -> `x-bf-vk`
- *               header, anything else -> `Authorization: Bearer <key>`)
- *   openrouter  OPENROUTER_API_KEY, OPENROUTER_BASE_URL (optional)
- *   vertex      GOOGLE_APPLICATION_CREDENTIALS (service-account JSON path),
- *               GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT,
- *               GOOGLE_CLOUD_LOCATION (optional, default us-central1)
+ *               header, anything else -> `Authorization: Bearer <key>`),
+ *               TWING_BIFROST_EXTRACT_MODEL / TWING_BIFROST_SEMANTIC_CHECK_MODEL
  */
 
-import { createSign } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { GoogleAuth } from "google-auth-library";
 
 // gemma-4-31b is only reachable via bedrock-mantle's OpenAI-compat route,
 // not its plain-Bedrock-model route -- everything else (glm-5, and per
@@ -77,55 +90,114 @@ export interface LlmCallOptions {
   /** Model id, in whatever form the selected provider expects -- a
    * Bedrock model id (`google.gemma-4-31b`), or a `provider/model` string
    * for Bifrost/OpenRouter/Vertex (`openai/gpt-4o-mini`,
-   * `google/gemini-2.0-flash`). */
+   * `google/gemini-2.0-flash`). Callers normally pass the result of
+   * `resolveExtractModel()` / `resolveSemanticCheckModel()`. */
   model: string;
   /** Bedrock only: omit to fall back to AWS_REGION/AWS_DEFAULT_REGION. */
   region?: string;
 }
 
-export type LlmProvider = "bedrock" | "bifrost" | "openrouter" | "vertex";
-
-const KNOWN_PROVIDERS: readonly LlmProvider[] = ["bedrock", "bifrost", "openrouter", "vertex"];
+export type LlmProvider = "bedrock" | "vertex" | "openrouter" | "bifrost";
 
 /**
- * Which provider a call will use right now, given the environment. An
- * explicit `TWING_LLM_PROVIDER` wins; otherwise the first provider whose
- * config is present, in precedence order, with Bedrock as the final
- * fallback (so a fully unconfigured server still throws "no credentials"
- * from `callBedrock` and the caller fails soft, unchanged behavior).
+ * Which provider a call will use right now, given the environment: the
+ * first one whose credential/base-URL var is present, in precedence order
+ * AWS -> GCP -> OpenRouter -> Bifrost. **Throws** if none is set -- there is
+ * no default provider. The throw is expected to reach a caller that fails
+ * soft (see this file's header comment).
  */
 export function selectProvider(): LlmProvider {
-  const explicit = process.env.TWING_LLM_PROVIDER?.trim().toLowerCase();
-  if (explicit && (KNOWN_PROVIDERS as readonly string[]).includes(explicit)) {
-    return explicit as LlmProvider;
-  }
   if (process.env.AWS_BEARER_TOKEN_BEDROCK) return "bedrock";
-  if (process.env.TWING_BIFROST_BASE_URL) return "bifrost";
-  if (process.env.OPENROUTER_API_KEY) return "openrouter";
   if (process.env.GOOGLE_APPLICATION_CREDENTIALS) return "vertex";
-  return "bedrock";
+  if (process.env.OPENROUTER_API_KEY) return "openrouter";
+  if (process.env.TWING_BIFROST_BASE_URL) return "bifrost";
+  throw new Error(
+    "no LLM provider configured -- set one of AWS_BEARER_TOKEN_BEDROCK, GOOGLE_APPLICATION_CREDENTIALS, OPENROUTER_API_KEY, or TWING_BIFROST_BASE_URL",
+  );
+}
+
+interface ProviderModels {
+  extractEnv: string;
+  extractDefault: string;
+  semanticEnv: string;
+  semanticDefault: string;
+}
+
+const PROVIDER_MODELS: Record<LlmProvider, ProviderModels> = {
+  bedrock: {
+    extractEnv: "TWING_BEDROCK_EXTRACT_MODEL",
+    extractDefault: "google.gemma-4-31b",
+    semanticEnv: "TWING_BEDROCK_SEMANTIC_CHECK_MODEL",
+    semanticDefault: "google.gemma-4-31b",
+  },
+  vertex: {
+    extractEnv: "TWING_VERTEX_EXTRACT_MODEL",
+    extractDefault: "google/gemini-2.0-flash",
+    semanticEnv: "TWING_VERTEX_SEMANTIC_CHECK_MODEL",
+    semanticDefault: "google/gemini-2.0-flash",
+  },
+  openrouter: {
+    extractEnv: "TWING_OPENROUTER_EXTRACT_MODEL",
+    extractDefault: "openai/gpt-4o-mini",
+    semanticEnv: "TWING_OPENROUTER_SEMANTIC_CHECK_MODEL",
+    semanticDefault: "openai/gpt-4o-mini",
+  },
+  bifrost: {
+    extractEnv: "TWING_BIFROST_EXTRACT_MODEL",
+    extractDefault: "openai/gpt-4o-mini",
+    semanticEnv: "TWING_BIFROST_SEMANTIC_CHECK_MODEL",
+    semanticDefault: "openai/gpt-4o-mini",
+  },
+};
+
+/** The extraction model for the active provider: `TWING_<PROVIDER>_EXTRACT_MODEL`
+ * if set, else the provider's default. Throws (via `selectProvider`) when no
+ * provider is configured. */
+export function resolveExtractModel(): string {
+  const m = PROVIDER_MODELS[selectProvider()];
+  return process.env[m.extractEnv]?.trim() || m.extractDefault;
+}
+
+/** The semantic-conflict-check model for the active provider:
+ * `TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL` if set, else the provider's default. */
+export function resolveSemanticCheckModel(): string {
+  const m = PROVIDER_MODELS[selectProvider()];
+  return process.env[m.semanticEnv]?.trim() || m.semanticDefault;
 }
 
 /** One-line, secret-free description of the active provider config, for
- * main.ts's startup log. `ready` is a best-effort "the obvious required
- * vars are present" check -- not a live call. */
-export function describeLlmProvider(): { provider: LlmProvider; ready: boolean; summary: string } {
-  const provider = selectProvider();
+ * main.ts's startup log. `provider` is null when none is configured. `ready`
+ * is a best-effort "the obvious required vars are present" check -- not a
+ * live call. */
+export function describeLlmProvider(): { provider: LlmProvider | null; ready: boolean; summary: string } {
+  let provider: LlmProvider;
+  try {
+    provider = selectProvider();
+  } catch {
+    return {
+      provider: null,
+      ready: false,
+      summary:
+        "no provider detected (need AWS_BEARER_TOKEN_BEDROCK / GOOGLE_APPLICATION_CREDENTIALS / OPENROUTER_API_KEY / TWING_BIFROST_BASE_URL)",
+    };
+  }
   switch (provider) {
     case "bedrock": {
       const region = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
-      const ready = Boolean(process.env.AWS_BEARER_TOKEN_BEDROCK && region);
       return {
         provider,
-        ready,
+        ready: Boolean(process.env.AWS_BEARER_TOKEN_BEDROCK && region),
         summary: `Bedrock (bedrock-mantle)${region ? `, region ${region}` : ", region unset"}`,
       };
     }
-    case "bifrost": {
-      const base = process.env.TWING_BIFROST_BASE_URL;
-      const key = process.env.TWING_BIFROST_API_KEY;
-      const auth = !key ? "no auth" : key.startsWith("sk-bf-") ? "virtual key" : "bearer token";
-      return { provider, ready: Boolean(base), summary: `Bifrost gateway at ${base ?? "(TWING_BIFROST_BASE_URL unset)"} (${auth})` };
+    case "vertex": {
+      const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
+      const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
+      return {
+        provider,
+        ready: Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS),
+        summary: `Vertex AI (project ${project ?? "from credentials"}, location ${location})`,
+      };
     }
     case "openrouter":
       return {
@@ -133,15 +205,11 @@ export function describeLlmProvider(): { provider: LlmProvider; ready: boolean; 
         ready: Boolean(process.env.OPENROUTER_API_KEY),
         summary: `OpenRouter at ${process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1"}`,
       };
-    case "vertex": {
-      const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
-      const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
-      const ready = Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS && project);
-      return {
-        provider,
-        ready,
-        summary: `Vertex AI (project ${project ?? "unset"}, location ${location})`,
-      };
+    case "bifrost": {
+      const base = process.env.TWING_BIFROST_BASE_URL;
+      const key = process.env.TWING_BIFROST_API_KEY;
+      const auth = !key ? "no auth" : key.startsWith("sk-bf-") ? "virtual key" : "bearer token";
+      return { provider, ready: Boolean(base), summary: `Bifrost gateway at ${base ?? "(TWING_BIFROST_BASE_URL unset)"} (${auth})` };
     }
   }
 }
@@ -179,6 +247,79 @@ async function callBedrock(messages: ChatMessage[], options: LlmCallOptions): Pr
   return parseChatCompletion(res, "Bedrock");
 }
 
+/** The bits of `google-auth-library` `callVertex` needs. Behind an
+ * interface only so `llm-client.test.ts` can swap in a fake via
+ * `__setVertexCredentialsForTests` instead of standing up real GCP
+ * credentials -- production always uses `googleAuthCredentials()`. */
+export interface VertexCredentials {
+  accessToken(): Promise<string>;
+  projectId(): Promise<string | undefined>;
+}
+
+let googleAuth: GoogleAuth | undefined;
+let vertexCredentialsOverride: VertexCredentials | undefined;
+
+/** Test-only: swap the credential source (pass `undefined` to restore). */
+export function __setVertexCredentialsForTests(v: VertexCredentials | undefined): void {
+  vertexCredentialsOverride = v;
+}
+
+/** `google-auth-library` loads `GOOGLE_APPLICATION_CREDENTIALS` / ADC /
+ * metadata-server credentials and caches + refreshes the token itself, so
+ * there is nothing to cache here. */
+function googleAuthCredentials(): VertexCredentials {
+  googleAuth ??= new GoogleAuth({ scopes: "https://www.googleapis.com/auth/cloud-platform" });
+  const auth = googleAuth;
+  return {
+    async accessToken() {
+      const token = await auth.getAccessToken();
+      if (!token) {
+        throw new Error(
+          "Vertex request failed: google-auth-library returned no access token -- check GOOGLE_APPLICATION_CREDENTIALS / application default credentials",
+        );
+      }
+      return token;
+    },
+    projectId: () => auth.getProjectId().catch(() => undefined),
+  };
+}
+
+async function callVertex(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
+  const creds = vertexCredentialsOverride ?? googleAuthCredentials();
+  const project =
+    process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT ?? (await creds.projectId());
+  if (!project) {
+    throw new Error("Vertex request failed: no project -- set GOOGLE_CLOUD_PROJECT (or use credentials that carry one)");
+  }
+  const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
+  const token = await creds.accessToken();
+
+  const res = await fetch(
+    `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/endpoints/openapi/chat/completions`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ model: options.model, messages }),
+    },
+  );
+  return parseChatCompletion(res, "Vertex");
+}
+
+async function callOpenRouter(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key) {
+    throw new Error("OpenRouter request failed: no credentials -- set OPENROUTER_API_KEY");
+  }
+  const base = (process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1").replace(/\/+$/, "");
+
+  const res = await fetch(`${base}/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${key}` },
+    body: JSON.stringify({ model: options.model, messages }),
+  });
+  return parseChatCompletion(res, "OpenRouter");
+}
+
 /** `sk-bf-...` -> Bifrost virtual key header; any other value -> bearer;
  * unset -> no auth header at all (a keyless localhost gateway). */
 function bifrostAuthHeaders(key: string | undefined): Record<string, string> {
@@ -202,135 +343,20 @@ async function callBifrost(messages: ChatMessage[], options: LlmCallOptions): Pr
   return parseChatCompletion(res, "Bifrost");
 }
 
-async function callOpenRouter(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
-  const key = process.env.OPENROUTER_API_KEY;
-  if (!key) {
-    throw new Error("OpenRouter request failed: no credentials -- set OPENROUTER_API_KEY");
-  }
-  const base = (process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1").replace(/\/+$/, "");
-
-  const res = await fetch(`${base}/chat/completions`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization: `Bearer ${key}` },
-    body: JSON.stringify({ model: options.model, messages }),
-  });
-  return parseChatCompletion(res, "OpenRouter");
-}
-
-interface ServiceAccountKey {
-  client_email: string;
-  private_key: string;
-  token_uri?: string;
-}
-
-let vertexTokenCache: { key: string; token: string; expiresAt: number } | null = null;
-
-function base64url(input: string | Buffer): string {
-  return (typeof input === "string" ? Buffer.from(input) : input).toString("base64url");
-}
-
-/** Mint (and cache) a cloud-platform access token from a service-account
- * key via the RS256 JWT bearer grant -- no `google-auth-library`. Cached
- * per `client_email` until ~1min before the token's own expiry. */
-async function vertexAccessToken(sa: ServiceAccountKey): Promise<string> {
-  const now = Date.now();
-  if (vertexTokenCache && vertexTokenCache.key === sa.client_email && vertexTokenCache.expiresAt > now + 60_000) {
-    return vertexTokenCache.token;
-  }
-  const tokenUri = sa.token_uri ?? "https://oauth2.googleapis.com/token";
-  const iat = Math.floor(now / 1000);
-  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
-  const claims = base64url(
-    JSON.stringify({
-      iss: sa.client_email,
-      scope: "https://www.googleapis.com/auth/cloud-platform",
-      aud: tokenUri,
-      iat,
-      exp: iat + 3600,
-    }),
-  );
-  const signingInput = `${header}.${claims}`;
-  const signature = base64url(createSign("RSA-SHA256").update(signingInput).sign(sa.private_key));
-  const assertion = `${signingInput}.${signature}`;
-
-  const res = await fetch(tokenUri, {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-      assertion,
-    }),
-  });
-  const body = (await res.json().catch(() => ({}))) as {
-    access_token?: string;
-    expires_in?: number;
-    error?: string;
-    error_description?: string;
-  };
-  if (!res.ok || !body.access_token) {
-    throw new Error(
-      `Vertex token exchange failed (${res.status}): ${body.error_description ?? body.error ?? JSON.stringify(body)}`,
-    );
-  }
-  vertexTokenCache = {
-    key: sa.client_email,
-    token: body.access_token,
-    expiresAt: now + (body.expires_in ?? 3600) * 1000,
-  };
-  return body.access_token;
-}
-
-async function callVertex(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
-  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-  if (!credPath) {
-    throw new Error(
-      "Vertex request failed: no credentials -- set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON path",
-    );
-  }
-  const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
-  if (!project) {
-    throw new Error("Vertex request failed: no project -- set GOOGLE_CLOUD_PROJECT");
-  }
-  const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
-
-  let sa: ServiceAccountKey;
-  try {
-    sa = JSON.parse(await readFile(credPath, "utf8")) as ServiceAccountKey;
-  } catch (err) {
-    throw new Error(
-      `Vertex request failed: could not read GOOGLE_APPLICATION_CREDENTIALS (${credPath}): ${err instanceof Error ? err.message : err}`,
-    );
-  }
-  if (!sa.client_email || !sa.private_key) {
-    throw new Error("Vertex request failed: GOOGLE_APPLICATION_CREDENTIALS is not a service-account key (no client_email/private_key)");
-  }
-  const token = await vertexAccessToken(sa);
-
-  const res = await fetch(
-    `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/endpoints/openapi/chat/completions`,
-    {
-      method: "POST",
-      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-      body: JSON.stringify({ model: options.model, messages }),
-    },
-  );
-  return parseChatCompletion(res, "Vertex");
-}
-
 /** The general form: a full message list (system + any few-shot user/
  * assistant example turns + the real user turn). `callLlm` below is a thin
  * convenience wrapper for the common single-system-message-plus-user-turn
- * case. Provider is chosen ambiently -- see `selectProvider`. */
+ * case. Provider is chosen ambiently -- see `selectProvider` (throws when
+ * none is configured). */
 export async function callLlmMessages(messages: ChatMessage[], options: LlmCallOptions): Promise<string> {
   switch (selectProvider()) {
-    case "bifrost":
-      return callBifrost(messages, options);
-    case "openrouter":
-      return callOpenRouter(messages, options);
     case "vertex":
       return callVertex(messages, options);
+    case "openrouter":
+      return callOpenRouter(messages, options);
+    case "bifrost":
+      return callBifrost(messages, options);
     case "bedrock":
-    default:
       return callBedrock(messages, options);
   }
 }

--- a/packages/server/src/llm-client.ts
+++ b/packages/server/src/llm-client.ts
@@ -62,7 +62,10 @@
  *   vertex      GOOGLE_APPLICATION_CREDENTIALS (service-account JSON path;
  *               also what selection keys off), GOOGLE_CLOUD_PROJECT /
  *               GCLOUD_PROJECT (or resolved from the credentials),
- *               GOOGLE_CLOUD_LOCATION (optional, default us-central1),
+ *               GOOGLE_CLOUD_LOCATION (optional, default "global" -- which,
+ *               like an explicit "global", hits the location-less host
+ *               aiplatform.googleapis.com; a regional value gets the
+ *               "{location}-" DNS prefix),
  *               TWING_VERTEX_EXTRACT_MODEL / TWING_VERTEX_SEMANTIC_CHECK_MODEL
  *   openrouter  OPENROUTER_API_KEY, OPENROUTER_BASE_URL (optional),
  *               TWING_OPENROUTER_EXTRACT_MODEL / TWING_OPENROUTER_SEMANTIC_CHECK_MODEL
@@ -192,7 +195,7 @@ export function describeLlmProvider(): { provider: LlmProvider | null; ready: bo
     }
     case "vertex": {
       const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
-      const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
+      const location = process.env.GOOGLE_CLOUD_LOCATION?.trim() || "global";
       return {
         provider,
         ready: Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS),
@@ -291,11 +294,15 @@ async function callVertex(messages: ChatMessage[], options: LlmCallOptions): Pro
   if (!project) {
     throw new Error("Vertex request failed: no project -- set GOOGLE_CLOUD_PROJECT (or use credentials that carry one)");
   }
-  const location = process.env.GOOGLE_CLOUD_LOCATION ?? "us-central1";
+  // Default and `global` both use the location-less host
+  // `aiplatform.googleapis.com` (the path still carries `locations/global`);
+  // any regional value gets the `{location}-` DNS prefix.
+  const location = process.env.GOOGLE_CLOUD_LOCATION?.trim() || "global";
+  const host = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`;
   const token = await creds.accessToken();
 
   const res = await fetch(
-    `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/endpoints/openapi/chat/completions`,
+    `https://${host}/v1/projects/${project}/locations/${location}/endpoints/openapi/chat/completions`,
     {
       method: "POST",
       headers: { "content-type": "application/json", authorization: `Bearer ${token}` },

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -3,7 +3,7 @@ import { createApp } from "./app.js";
 import { createDb } from "./db/client.js";
 import { ConstraintStore } from "./design-store.js";
 import { IdentityStore } from "./identity-store.js";
-import { describeLlmProvider } from "./llm-client.js";
+import { describeLlmProvider, resolveExtractModel, resolveSemanticCheckModel } from "./llm-client.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const dataDirOptions = process.env.TWING_SERVE_DATA_DIR ? { dataDir: process.env.TWING_SERVE_DATA_DIR } : {};
@@ -37,21 +37,23 @@ if (process.argv.includes("--regenerate-bootstrap-token")) {
 const db = createDb(dataDirOptions);
 
 // §17.3/§17.6: design-gate extraction and constraint persistence config.
-// Bedrock (bedrock-mantle) is the default LLM path; Bifrost, OpenRouter,
-// and GCP Vertex AI are also selectable -- picked ambiently by
-// TWING_LLM_PROVIDER or credential auto-detection in llm-client.ts (see
-// its header comment for the env vars and precedence). No API-key precheck
-// here: every provider reads its own credentials from the environment, and
-// a misconfigured deployment finds out when the real call fails and falls
-// soft, not from a separate presence check. The model default below is a
-// Bedrock model id -- an operator pointing at Bifrost/OpenRouter/Vertex
-// must set TWING_EXTRACT_MODEL / TWING_SEMANTIC_CHECK_MODEL to that
-// provider's own model string (e.g. `openai/gpt-4o-mini`).
-const extractModel = process.env.TWING_EXTRACT_MODEL ?? "google.gemma-4-31b";
-
-// design-semantic-check.ts's async comparator -- same ambient-credential
-// resolution, same model default (this repo's own eval settled on it).
-const semanticCheckModel = process.env.TWING_SEMANTIC_CHECK_MODEL ?? "google.gemma-4-31b";
+// The LLM provider is auto-detected from the environment by llm-client.ts
+// (AWS -> GCP -> OpenRouter -> Bifrost precedence; no TWING_LLM_PROVIDER
+// override), and the model is chosen per provider from
+// TWING_<PROVIDER>_EXTRACT_MODEL / TWING_<PROVIDER>_SEMANTIC_CHECK_MODEL
+// with provider-appropriate defaults -- see llm-client.ts's header. When no
+// provider is configured, `resolve*Model()` throws (via `selectProvider`);
+// we swallow that here so the server still starts (extraction just fails
+// soft to "clean", logged below), and pass empty model ids the real call
+// path never gets far enough to use.
+let extractModel = "";
+let semanticCheckModel = "";
+try {
+  extractModel = resolveExtractModel();
+  semanticCheckModel = resolveSemanticCheckModel();
+} catch {
+  // no provider configured -- handled by the startup log + fail-soft path
+}
 
 // twing-monitor v1: comma-separated browser-origin allowlist, e.g.
 // "https://app.twing.dev,http://localhost:5173". Unset/empty -- the
@@ -116,22 +118,21 @@ serve({ fetch: app.fetch, port, hostname }, (info) => {
     }
   }
   const llm = describeLlmProvider();
-  if (llm.ready) {
+  if (!llm.provider) {
+    console.log(
+      `twing serve: no LLM provider configured (${llm.summary}) -- ExitPlanMode design extraction and async semantic-conflict checks ` +
+        "will fail soft to 'clean' / 'no conflict'. The gate still enforces the Edit|Write \"must have a registered design\" rule either way.",
+    );
+  } else if (llm.ready) {
     console.log(
       `twing serve: LLM provider ${llm.provider} -- ${llm.summary}. Design extraction uses model ${extractModel}, ` +
         `semantic-conflict checks use model ${semanticCheckModel}.`,
     );
   } else {
     console.log(
-      `twing serve: LLM provider ${llm.provider} (${llm.summary}) is not fully configured -- ExitPlanMode design extraction (model ${extractModel}) ` +
+      `twing serve: LLM provider ${llm.provider} (${llm.summary}) detected but not fully configured -- design extraction (model ${extractModel}) ` +
         `will fail soft to 'clean', and async semantic-conflict checks (model ${semanticCheckModel}) will fail soft to 'no conflict'. ` +
         "The gate still enforces the Edit|Write \"must have a registered design\" rule either way.",
-    );
-  }
-  if (llm.ready && llm.provider !== "bedrock" && !extractModel.includes("/")) {
-    console.log(
-      `twing serve: WARNING -- LLM provider is ${llm.provider} but TWING_EXTRACT_MODEL/TWING_SEMANTIC_CHECK_MODEL still look Bedrock-shaped ` +
-        `(${extractModel}). Set them to a ${llm.provider} model string (e.g. "openai/gpt-4o-mini") or extraction will fail soft to 'clean'.`,
     );
   }
 });

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -3,6 +3,7 @@ import { createApp } from "./app.js";
 import { createDb } from "./db/client.js";
 import { ConstraintStore } from "./design-store.js";
 import { IdentityStore } from "./identity-store.js";
+import { describeLlmProvider } from "./llm-client.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const dataDirOptions = process.env.TWING_SERVE_DATA_DIR ? { dataDir: process.env.TWING_SERVE_DATA_DIR } : {};
@@ -36,13 +37,16 @@ if (process.argv.includes("--regenerate-bootstrap-token")) {
 const db = createDb(dataDirOptions);
 
 // §17.3/§17.6: design-gate extraction and constraint persistence config.
-// Bedrock-only (OpenRouter support removed 2026-08-17 -- the org
-// standardized on AWS Bedrock and never wants a second LLM vendor in this
-// loop). No API-key precheck the way OpenRouter needed: Bedrock reads
-// AWS_BEARER_TOKEN_BEDROCK/AWS_REGION ambiently from the environment
-// (llm-client.ts), same as any other AWS-authenticated process -- a
-// misconfigured deployment finds out when the real call fails and falls
-// soft, not from a separate presence check.
+// Bedrock (bedrock-mantle) is the default LLM path; Bifrost, OpenRouter,
+// and GCP Vertex AI are also selectable -- picked ambiently by
+// TWING_LLM_PROVIDER or credential auto-detection in llm-client.ts (see
+// its header comment for the env vars and precedence). No API-key precheck
+// here: every provider reads its own credentials from the environment, and
+// a misconfigured deployment finds out when the real call fails and falls
+// soft, not from a separate presence check. The model default below is a
+// Bedrock model id -- an operator pointing at Bifrost/OpenRouter/Vertex
+// must set TWING_EXTRACT_MODEL / TWING_SEMANTIC_CHECK_MODEL to that
+// provider's own model string (e.g. `openai/gpt-4o-mini`).
 const extractModel = process.env.TWING_EXTRACT_MODEL ?? "google.gemma-4-31b";
 
 // design-semantic-check.ts's async comparator -- same ambient-credential
@@ -111,13 +115,23 @@ serve({ fetch: app.fetch, port, hostname }, (info) => {
       console.log(`twing serve: WARNING -- bound to ${explicitHost} with --no-auth set. Anyone who can reach this port can write as any self-declared developer id. Loopback-only (127.0.0.1) is the safe default; only override this on a network you trust.`);
     }
   }
-  if (!process.env.AWS_BEARER_TOKEN_BEDROCK) {
+  const llm = describeLlmProvider();
+  if (llm.ready) {
     console.log(
-      `twing serve: AWS_BEARER_TOKEN_BEDROCK not set -- ExitPlanMode design extraction (model ${extractModel}) will fail soft to 'clean', ` +
-        `and async semantic-conflict checks (model ${semanticCheckModel}) will fail soft to 'no conflict'. The gate still enforces the ` +
-        "Edit|Write \"must have a registered design\" rule either way.",
+      `twing serve: LLM provider ${llm.provider} -- ${llm.summary}. Design extraction uses model ${extractModel}, ` +
+        `semantic-conflict checks use model ${semanticCheckModel}.`,
     );
   } else {
-    console.log(`twing serve: using Bedrock for design extraction (model ${extractModel}) and semantic-conflict checks (model ${semanticCheckModel}), region from the environment`);
+    console.log(
+      `twing serve: LLM provider ${llm.provider} (${llm.summary}) is not fully configured -- ExitPlanMode design extraction (model ${extractModel}) ` +
+        `will fail soft to 'clean', and async semantic-conflict checks (model ${semanticCheckModel}) will fail soft to 'no conflict'. ` +
+        "The gate still enforces the Edit|Write \"must have a registered design\" rule either way.",
+    );
+  }
+  if (llm.ready && llm.provider !== "bedrock" && !extractModel.includes("/")) {
+    console.log(
+      `twing serve: WARNING -- LLM provider is ${llm.provider} but TWING_EXTRACT_MODEL/TWING_SEMANTIC_CHECK_MODEL still look Bedrock-shaped ` +
+        `(${extractModel}). Set them to a ${llm.provider} model string (e.g. "openai/gpt-4o-mini") or extraction will fail soft to 'clean'.`,
+    );
   }
 });


### PR DESCRIPTION
## What

`twing serve`'s two design-gate LLM calls (`design-extract.ts`,
`design-semantic-check.ts`) now route through a unified provider dispatch in
`packages/server/src/llm-client.ts`. **AWS Bedrock (`bedrock-mantle`) stays the
default and its code path is byte-for-byte unchanged.** Adds **Bifrost**,
**OpenRouter**, and **GCP Vertex AI** as alternatives.

## Provider selection

`TWING_LLM_PROVIDER=bedrock|bifrost|openrouter|vertex` forces the choice.
Unset, `selectProvider()` auto-detects from which credential/base-URL vars are
present, **Bedrock winning ties**.

| Provider | Vars | Notes |
|---|---|---|
| bedrock | `AWS_BEARER_TOKEN_BEDROCK`, `AWS_REGION` | default, unchanged |
| bifrost | `TWING_BIFROST_BASE_URL`, `TWING_BIFROST_API_KEY?` | `POST {base}/v1/chat/completions`; `sk-bf-*` key → `x-bf-vk` header, else `Bearer`, unset → no auth header; trailing slash normalised |
| openrouter | `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL?` | |
| vertex | `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION?` | SA-key → RS256 JWT → OAuth token via `node:crypto`, cached in-process. **No `google-auth-library` dependency** — matches the module's no-SDK stance. |

All four share one OpenAI chat-completions request/response shape and one
parser. `callLlm` / `callLlmMessages` signatures unchanged, so
`design-extract.ts` / `design-semantic-check.ts` are untouched.

Bifrost/OpenRouter/Vertex need `TWING_EXTRACT_MODEL` /
`TWING_SEMANTIC_CHECK_MODEL` set to that provider's own `provider/model`
string (the default `google.gemma-4-31b` is a Bedrock id). `main.ts`'s
startup log is now provider-aware and warns on that mismatch.

Missing/misconfigured credentials still **fail soft to "clean"** — the real
call throws, retries once, then the caller falls soft. No separate precheck.

## Docs

`README.md`, `deploy/README.md`, `deploy/docker/.env.example`, `CLAUDE.md`,
and design doc §17.3 (which was stale — still described OpenRouter as removed).

## Testing

- `packages/server/src/llm-client.test.ts`: 19 cases (12 new) — per-provider
  routing/auth/error, `selectProvider` precedence, Vertex JWT+token-cache
  with a generated RSA key, `describeLlmProvider`.
- Full suites on Node 22: `@twing/server` 400/400, `@twing/core` 34/34,
  `@twing/cli` 113/113. (`@twing/simulator` has one unrelated failure —
  `version-gate.test.js` needs the Go toolchain, not installed in this env.)
- Not run: live round-trip against a real Bifrost / Vertex endpoint (no
  credentials available).

## Coordination note

This supersedes in-progress design `acf45aa0` (Vertex + OpenRouter only) on
the twing coordinator — folded into this one seam alongside Bifrost per
operator direction. That session will collide with these files.
