### PR TITLE
Fix Vertex AI's default model (404s on live catalog)

### DIFF
--- a/packages/server/src/llm-client.test.ts
+++ b/packages/server/src/llm-client.test.ts
@@ -241,7 +241,7 @@ test("resolveExtractModel / resolveSemanticCheckModel: per-provider default, ove
     assert.equal(resolveExtractModel(), "openai/gpt-4o-mini");
   });
   await withEnv({ GOOGLE_APPLICATION_CREDENTIALS: "/sa.json" }, async () => {
-    assert.equal(resolveExtractModel(), "google/gemini-2.0-flash");
+    assert.equal(resolveExtractModel(), "google/gemini-2.5-flash");
   });
   await withEnv(
     { OPENROUTER_API_KEY: "k", TWING_OPENROUTER_EXTRACT_MODEL: "anthropic/claude-3-5-haiku", TWING_OPENROUTER_SEMANTIC_CHECK_MODEL: "openai/gpt-4o" },

--- a/packages/server/src/llm-client.ts
+++ b/packages/server/src/llm-client.ts
@@ -135,9 +135,13 @@ const PROVIDER_MODELS: Record<LlmProvider, ProviderModels> = {
   },
   vertex: {
     extractEnv: "TWING_VERTEX_EXTRACT_MODEL",
-    extractDefault: "google/gemini-2.0-flash",
+    // gemini-2.0-flash 404s on the live twing-app Vertex catalog (both
+    // "global" and a regional location) with no operator override --
+    // confirmed live 2026-08-30. gemini-2.5-flash is live-verified working
+    // against the same project via this exact callVertex path.
+    extractDefault: "google/gemini-2.5-flash",
     semanticEnv: "TWING_VERTEX_SEMANTIC_CHECK_MODEL",
-    semanticDefault: "google/gemini-2.0-flash",
+    semanticDefault: "google/gemini-2.5-flash",
   },
   openrouter: {
     extractEnv: "TWING_OPENROUTER_EXTRACT_MODEL",


### PR DESCRIPTION
`PROVIDER_MODELS.vertex`'s default extract/semantic-check model
(`google/gemini-2.0-flash`) 404s against the live `twing-app` Vertex
catalog, in both `global` and `us-central1`, with zero operator overrides
— exactly what a fresh deployment following the README ends up with.
Live-tested against the real `callVertex` path (`GOOGLE_APPLICATION_CREDENTIALS`
+ `GOOGLE_CLOUD_PROJECT`, no model env var set).

`google/gemini-2.5-flash` is confirmed working against the same project/
credentials. Swapped both defaults, updated the one test assertion that
hardcoded the old value.

Full monorepo build + test green (552/552) before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
