### PR TITLE
Fix structural gaps in the design gate's cross-project registration flow

### DIFF
--- a/hook/design_gate.go
+++ b/hook/design_gate.go
@@ -186,6 +186,15 @@ type designCheckResponse struct {
 	// groupId (self-assigned or caller-supplied). Not consumed by any
 	// gate decision today -- available for future logging/diagnostics.
 	GroupID string `json:"groupId,omitempty"`
+	// Creates/Touches (existence-check advisory, 2026-08-31): only ever set
+	// for a `rawPlanText` (ExitPlanMode) request -- app.ts echoes back
+	// what design-extract.ts resolved server-side, since this is otherwise
+	// the only way the hook ever learns what got extracted. Used by
+	// warnIfTouchesMissing below to catch a likely wrong-project
+	// registration; never set for a structured `register` call, which
+	// already had these client-side.
+	Creates []string `json:"creates,omitempty"`
+	Touches []string `json:"touches,omitempty"`
 }
 
 // blocksGate reports whether this response's verdict should deny the tool
@@ -194,9 +203,11 @@ type designCheckResponse struct {
 // core/types.ts). `/v1/designs/check`/`amend`/`resume` (design-checks.ts
 // tiers 1/3, the only source of a `designCheckResponse`) can only ever
 // return "clean", "file_overlap" (always advisory), or "constraint_violation"
-// (always blocks) -- anything else (e.g. "has_open_designs") falls through
-// to the caller's own "unknown verdict" fail-closed default, unchanged from
-// before this rename.
+// (always blocks) -- anything else falls through to the caller's own
+// "unknown verdict" fail-closed default, unchanged from before this rename.
+// ("has_open_designs" used to be a possible value here too, for a
+// structured `register` call only -- retired 2026-08-31, see app.ts's
+// removed pre-registration check for why.)
 func (r designCheckResponse) blocksGate() bool {
 	return r.Verdict != "clean" && r.Verdict != "file_overlap"
 }
@@ -272,6 +283,52 @@ func allowOutput(eventName string) map[string]any {
 		"hookSpecificOutput": map[string]any{
 			"hookEventName":      eventName,
 			"permissionDecision": "allow",
+		},
+	}
+}
+
+// allowOutputWithContext is allowOutput plus additionalContext -- same
+// field main.go's capture path already uses for a different hook event,
+// reused here so an ExitPlanMode registration is never silent. Found live,
+// 2026-08-31: a plan approved from the wrong repo's cwd registered a design
+// under the wrong project with zero feedback of any kind, and nothing
+// caught it until an unrelated later command happened to surface it. This
+// is the fix for that class of miss -- report what got registered and
+// where, every time, so a wrong project is visible the moment it happens
+// rather than discovered later by accident.
+// warnIfTouchesMissing returns a non-blocking advisory line, or "" when
+// nothing looks wrong. Fires only when repoRoot is known and *none* of
+// touches exist under it -- mirrors packages/cli/src/design.ts's
+// warnIfTouchesMissing exactly (same threshold, same two-branch guidance),
+// this is just the ExitPlanMode-path copy, since the check has to run
+// wherever repoRoot is actually known (client-side in both cases, for
+// different reasons -- see design.ts's own doc comment). `creates` is
+// deliberately not checked: it legitimately doesn't exist yet.
+func warnIfTouchesMissing(repoRoot, projectID string, touches []string) string {
+	if repoRoot == "" || len(touches) == 0 {
+		return ""
+	}
+	for _, t := range touches {
+		if _, err := os.Stat(filepath.Join(repoRoot, t)); err == nil {
+			return "" // one real match is enough to assume this repo is plausible
+		}
+	}
+	return fmt.Sprintf(
+		"twing: none of this design's declared files exist under %s for project %s. If this plan is actually "+
+			"about a different repo, move it: twing design amend --id <id> --reassign-project (run from the "+
+			"correct repo) -- or close and re-register if that's refused (already has reviews/threads attached). "+
+			"If this plan genuinely spans multiple repos, register a separate design in each one with that repo's "+
+			"own file list, then link them: twing design register --touches <paths> --group <groupId>.",
+		repoRoot, projectID,
+	)
+}
+
+func allowOutputWithContext(eventName, context string) map[string]any {
+	return map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":      eventName,
+			"permissionDecision": "allow",
+			"additionalContext":  context,
 		},
 	}
 }
@@ -670,9 +727,13 @@ func handleExitPlanModeSingle(payload hookPayload, config twingConfig) {
 		return
 	}
 
+	registeredContext := fmt.Sprintf("twing: registered design %s for project %s", result.DesignID, projectID)
+	if warning := warnIfTouchesMissing(config.RepoRoot, projectID, result.Touches); warning != "" {
+		registeredContext = registeredContext + "\n" + warning
+	}
 	switch {
 	case result.Verdict == "clean":
-		writeJSON(allowOutput("PreToolUse"))
+		writeJSON(allowOutputWithContext("PreToolUse", registeredContext))
 	case !result.blocksGate():
 		// 2026-08-26: "file_overlap" (renamed from "overlap") is always
 		// advisory now -- registers and allows same as clean. The conflict
@@ -680,7 +741,7 @@ func handleExitPlanModeSingle(payload hookPayload, config twingConfig) {
 		// -- see DesignVerdict's doc comment, core/types.ts, for why blocking
 		// is now a static function of verdict alone with no separate
 		// severity to check.
-		writeJSON(allowOutput("PreToolUse"))
+		writeJSON(allowOutputWithContext("PreToolUse", registeredContext))
 	case result.Verdict == "constraint_violation":
 		writeJSON(denyOutput("PreToolUse", constraintReason(result)))
 	default:
@@ -740,6 +801,7 @@ func handleExitPlanModeMultiCandidate(payload hookPayload) {
 	}
 
 	var denyReasons []string
+	var registeredContexts []string
 	matchedAny := false
 
 	for _, key := range order {
@@ -794,6 +856,18 @@ func handleExitPlanModeMultiCandidate(payload hookPayload) {
 				// The second case is 2026-08-26: "file_overlap" (renamed from
 				// "overlap") always registers and allows, same as clean, same
 				// reasoning as the single-repo path above.
+				msg := fmt.Sprintf("[%s] registered design %s for project %s", cand.DirName, result.DesignID, projectID)
+				// Lower value here than the single-repo path (the
+				// directory-name-prefix filter above already gives some
+				// matching signal), but cheap and worth the parity -- uses
+				// the locally-known `touches` directly rather than the
+				// echoed-back response field, since a structured request
+				// (like this one) never gets that field populated (see
+				// app.ts's rawPlanText-only gate on it).
+				if warning := warnIfTouchesMissing(cand.RepoRoot, projectID, touches); warning != "" {
+					msg = msg + "\n" + warning
+				}
+				registeredContexts = append(registeredContexts, msg)
 			case result.Verdict == "constraint_violation":
 				denyReasons = append(denyReasons, fmt.Sprintf("[%s] %s", cand.DirName, constraintReason(result)))
 			default:
@@ -816,7 +890,7 @@ func handleExitPlanModeMultiCandidate(payload hookPayload) {
 		writeJSON(denyOutput("PreToolUse", strings.Join(denyReasons, "\n\n")))
 		return
 	}
-	writeJSON(allowOutput("PreToolUse"))
+	writeJSON(allowOutputWithContext("PreToolUse", "twing: "+strings.Join(registeredContexts, "\n")))
 }
 
 // postDesignCheck posts to /v1/designs/check (structured or rawPlanText,
@@ -1083,7 +1157,7 @@ type designScopeMatchResponse struct {
 	// Set only for state "flagged" (2026-08-26, second pass): which of the
 	// four buckets actually flagged this design -- "constraint_violation" |
 	// "symbol_conflict" | "llm_divergence" (never "file_overlap", which
-	// doesn't flag, or "clean"/"has_open_designs", which don't apply here).
+	// doesn't flag, or "clean", which doesn't apply here).
 	// Lets flaggedDesignReason name the actual reason instead of one
 	// generic sentence for all three. Deliberately backward-compatible,
 	// same reasoning as OpenDesigns below: an older coordinator that
@@ -1218,11 +1292,11 @@ func flaggedDesignReason(designID string, pendingReview bool, requiresAdmin bool
 			// (design-store.ts) already accepts a design out of any of
 			// open/flagged/dormant unconditionally, the gate just never told
 			// anyone that was an option. Mirrors the same three-way
-			// join/close/force shape `has_open_designs`'s own deny message
-			// (design.ts's printDesignVerdict) already uses, uniformly
-			// across all three flagging verdicts rather than special-cased
-			// per bucket -- closing is just as valid a response to "someone
-			// beat you to this" as it is to "you've since moved on".
+			// join/close/force shape the now-retired `has_open_designs`
+			// verdict's deny message used to use, uniformly across all
+			// three flagging verdicts rather than special-cased per bucket
+			// -- closing is just as valid a response to "someone beat you
+			// to this" as it is to "you've since moved on".
 			{
 				Label:   "Or, if that work is done and this doesn't apply anymore",
 				Command: fmt.Sprintf("twing design close --id %s", designID),
@@ -1239,10 +1313,9 @@ func flaggedDesignReason(designID string, pendingReview bool, requiresAdmin bool
 // whether the actual cause was a real edit collision, a stated-intent
 // conflict, or a project rule. Falls back to that original generic wording
 // for "" (an older coordinator that predates the Verdict field) and for any
-// verdict this deny path shouldn't structurally see (`"clean"` /
-// `"has_open_designs"` never flag; `"file_overlap"` never blocks) --
-// unrecognized is treated the same as unset rather than risking a blank
-// lead sentence.
+// verdict this deny path shouldn't structurally see (`"clean"` never
+// flags; `"file_overlap"` never blocks) -- unrecognized is treated the
+// same as unset rather than risking a blank lead sentence.
 func flaggedLeadAndDetail(verdict string) (lead string, detail string) {
 	switch verdict {
 	case "constraint_violation":

--- a/hook/design_gate_test.go
+++ b/hook/design_gate_test.go
@@ -692,6 +692,86 @@ func TestHandleExitPlanMode_CleanVerdict_Allows(t *testing.T) {
 	}
 }
 
+// additionalContextOf pulls hookSpecificOutput.additionalContext out of a
+// captured stdout payload, "" if absent -- allowOutputWithContext's own
+// field, distinct from decisionOf's permissionDecision/reason pair.
+func additionalContextOf(t *testing.T, stdout string) string {
+	t.Helper()
+	if stdout == "" {
+		return ""
+	}
+	var parsed struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	return parsed.HookSpecificOutput.AdditionalContext
+}
+
+// Change A (2026-08-31): a silent successful registration was exactly how
+// the incident that led to this whole file's changes went undetected --
+// see allowOutputWithContext's own doc comment.
+func TestHandleExitPlanMode_CleanVerdict_ReportsWhatItRegistered(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"verdict":"clean","designId":"d1"}`))
+	}))
+	defer server.Close()
+
+	repo := newTestRepo(t, server.URL)
+	setCachedToken(t, server.URL, "some-token")
+
+	stdout := captureStdout(t, func() { handleExitPlanMode(planPayload(repo, "sess1")) })
+	ctx := additionalContextOf(t, stdout)
+	if !strings.Contains(ctx, "registered design d1 for project") {
+		t.Fatalf("additionalContext = %q, want it to name the registered design and project", ctx)
+	}
+}
+
+// Change C (2026-08-31): the existence-check advisory. computeProjectID
+// requires a real git remote to produce a stable id, but that's incidental
+// here -- the check only cares whether declared `touches` exist under
+// repoRoot, so any value flowing through is fine.
+func TestHandleExitPlanMode_WarnsWhenNoDeclaredTouchesExist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"verdict":"clean","designId":"d1","touches":["src/does-not-exist.go"]}`))
+	}))
+	defer server.Close()
+
+	repo := newTestRepo(t, server.URL)
+	setCachedToken(t, server.URL, "some-token")
+
+	stdout := captureStdout(t, func() { handleExitPlanMode(planPayload(repo, "sess1")) })
+	ctx := additionalContextOf(t, stdout)
+	if !strings.Contains(ctx, "none of this design's declared files exist") {
+		t.Fatalf("additionalContext = %q, want the existence-check warning", ctx)
+	}
+	if !strings.Contains(ctx, "--reassign-project") || !strings.Contains(ctx, "--group") {
+		t.Fatalf("additionalContext = %q, want both suggested commands (move / multi-repo link)", ctx)
+	}
+}
+
+func TestHandleExitPlanMode_NoWarningWhenADeclaredTouchExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"verdict":"clean","designId":"d1","touches":["real.go","also-missing.go"]}`))
+	}))
+	defer server.Close()
+
+	repo := newTestRepo(t, server.URL)
+	if err := os.WriteFile(filepath.Join(repo, "real.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setCachedToken(t, server.URL, "some-token")
+
+	stdout := captureStdout(t, func() { handleExitPlanMode(planPayload(repo, "sess1")) })
+	ctx := additionalContextOf(t, stdout)
+	if strings.Contains(ctx, "none of this design's declared files exist") {
+		t.Fatalf("additionalContext = %q, want no warning -- one real match is enough", ctx)
+	}
+}
+
 // §17 design linking (2026-08): a genuinely single-repo plan (no sibling
 // candidates discovered, so handleExitPlanModeSingle handles it, not the
 // multi-candidate path) must never invent a groupId -- the server's own

--- a/packages/cli/src/design.test.ts
+++ b/packages/cli/src/design.test.ts
@@ -134,48 +134,41 @@ test("runDesignRegister: prints no group line when the response has no groupId",
   });
 });
 
-// "Force a choice" registration-sprawl fix (2026-08-25)
+// Existence-check advisory (2026-08-31)
 
-test("runDesignRegister: --force sends force: true in the request body", async () => {
-  const { fetch, calls } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1", groupId: "d1" }));
+test("runDesignRegister: warns when none of --touches exist under the repo root", async () => {
+  const { fetch } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1" }));
   await withHome(async () => {
     cacheToken(SERVER_URL, "test-token");
     const repo = tmpRepo(SERVER_URL);
-    await withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "genuinely new", force: true }));
-    const body = calls[0].body as Record<string, unknown>;
-    assert.equal(body.force, true);
+    const { warnings } = await captureConsole(() =>
+      withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "solo", touches: "src/does-not-exist.ts" })),
+    );
+    assert.ok(warnings.some((w) => w.includes("none of the declared --touches files exist")));
+    assert.ok(warnings.some((w) => w.includes("--reassign-project")));
+    assert.ok(warnings.some((w) => w.includes("--group")));
   });
 });
 
-test("runDesignRegister: omitting --force sends no force field at all", async () => {
-  const { fetch, calls } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1", groupId: "d1" }));
+test("runDesignRegister: stays quiet when at least one --touches path exists under the repo root", async () => {
+  const { fetch } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1" }));
   await withHome(async () => {
     cacheToken(SERVER_URL, "test-token");
     const repo = tmpRepo(SERVER_URL);
-    await withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "solo" }));
-    const body = calls[0].body as Record<string, unknown>;
-    assert.equal("force" in body, false, "must be omitted entirely, not sent as an explicit false");
+    fs.mkdirSync(path.join(repo, "src"), { recursive: true });
+    fs.writeFileSync(path.join(repo, "src", "real.ts"), "");
+    const { warnings } = await captureConsole(() =>
+      withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "solo", touches: "src/real.ts,src/also-missing.ts" })),
+    );
+    assert.equal(warnings.length, 0, "one real match is enough to stay quiet");
   });
 });
 
-test("runDesignRegister: a has_open_designs verdict lists the other open designs and the three next-step commands", async () => {
-  const { fetch } = captureFetch(
-    jsonResponse({
-      verdict: "has_open_designs",
-      openDesigns: [{ id: "d-old", projectId: "proj-x", summary: "an older, still-open task", lastActivityAt: 1 }],
-    }),
-  );
-  await withHome(async () => {
-    cacheToken(SERVER_URL, "test-token");
-    const repo = tmpRepo(SERVER_URL);
-    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignRegister({ cwd: repo, session: "sess1", summary: "new task" })));
-    assert.ok(logs.some((l) => l.includes("verdict: has_open_designs")));
-    assert.ok(logs.some((l) => l.includes("d-old") && l.includes("an older, still-open task")));
-    assert.ok(logs.some((l) => l.includes("--group")));
-    assert.ok(logs.some((l) => l.includes("design close")));
-    assert.ok(logs.some((l) => l.includes("--force")));
-  });
-});
+// "Force a choice" registration-sprawl fix (2026-08-25) -- retired
+// 2026-08-31, along with its `--force` escape hatch and `has_open_designs`
+// verdict. See DesignVerdict's doc comment (core/types.ts) and
+// app.test.ts's replacement coverage (the same scenario now produces a
+// `design_stale_sibling_suggested` notice instead of a block).
 
 // --- runDesignResolve --------------------------------------------------------
 
@@ -299,6 +292,30 @@ test("runDesignAmend: --group alongside --summary sends both", async () => {
     const repo = tmpRepo(SERVER_URL);
     await withMockFetch(fetch, () => runDesignAmend({ cwd: repo, id: "d1", summary: "joining the group", group: "anchor-id" }));
     assert.deepEqual(calls[0].body, { addTouches: [], addCreates: [], addDependsOn: [], summary: "joining the group", groupId: "anchor-id" });
+  });
+});
+
+// Change D (2026-08-31): --reassign-project's cwd resolution -- resolves
+// the *new* projectId from wherever the command is actually run, the same
+// way `register` already does, so there's no raw project-id hash to paste.
+test("runDesignAmend: --reassign-project resolves the new projectId from cwd and sends only reassignProjectId", async () => {
+  const { fetch, calls } = captureFetch(jsonResponse({ verdict: "clean", designId: "d1", projectId: "new-project-id" }));
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignAmend({ cwd: repo, id: "d1", reassignProject: true })));
+    assert.match(calls[0].url, /\/v1\/designs\/d1\/amend$/);
+    assert.deepEqual(calls[0].body, { reassignProjectId: computeProjectId(repo) });
+    assert.ok(logs.some((l) => l.includes("now in project: new-project-id")));
+  });
+});
+
+test("runDesignAmend: --reassign-project rejects being combined with any scope-amend field", async () => {
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    await assert.rejects(() => runDesignAmend({ cwd: repo, id: "d1", reassignProject: true, touches: "a.ts" }), /--reassign-project can't be combined/);
+    await assert.rejects(() => runDesignAmend({ cwd: repo, id: "d1", reassignProject: true, group: "anchor-id" }), /--reassign-project can't be combined/);
   });
 });
 

--- a/packages/cli/src/design.ts
+++ b/packages/cli/src/design.ts
@@ -8,6 +8,8 @@
  * this one.
  */
 
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { readConfig, getServerAuth, findRepoRoot, loadManifestFromFile, twingConfigPath, computeProjectId, computeDeveloperId, authFetch, isGateDisabled, setGateDisabled } from "@twing/core";
 
 interface RequiredConfig {
@@ -45,6 +47,35 @@ function splitList(value?: string): string[] {
 
 const UNAUTHORIZED_HINT = "unauthorized -- run `twing login` to re-authenticate";
 
+/**
+ * Existence-check advisory (2026-08-31): `touches` is only ever meant to
+ * name files that already exist under this repo -- unlike `creates`, which
+ * legitimately doesn't. Found live: a design's `touches` can be
+ * project-mismatched (registered against the wrong repo entirely) or, for
+ * a genuinely multi-repo plan, only partially relevant here, and neither
+ * looks any different from a correct registration until a human goes
+ * looking. Deliberately advisory only, printed to stdout rather than
+ * thrown -- a caller-supplied path that's merely relative to a
+ * subdirectory, or a real typo, shouldn't block a registration a human
+ * clearly meant to make; this just makes a wrong-repo case visible
+ * immediately instead of silently, same reasoning as the equivalent check
+ * in hook/design_gate.go's ExitPlanMode path. Fires only when *none* of
+ * the declared touches exist -- one match is enough to assume this repo is
+ * plausible and stay quiet.
+ */
+function warnIfTouchesMissing(repoRoot: string, touches: string[]): void {
+  if (touches.length === 0) return;
+  const anyExists = touches.some((t) => existsSync(join(repoRoot, t)));
+  if (anyExists) return;
+  console.warn(
+    `twing design: none of the declared --touches files exist under ${repoRoot}. If this design is actually about a ` +
+      `different repo, move it: twing design amend --id <id> --reassign-project (run from the correct repo) -- or ` +
+      `close and re-register if that's refused (already has reviews/threads attached). If this design genuinely ` +
+      `spans multiple repos, register a separate design in each one with that repo's own file list, then link them ` +
+      `with the same --group.`,
+  );
+}
+
 interface DesignConflictJSON {
   conflictingDesignId: string;
   overlapKind: string;
@@ -55,16 +86,16 @@ interface DesignConflictJSON {
 interface DesignCheckResponseJSON {
   error?: string;
   /** 2026-08-26 terminology simplification: renamed from
-   * `"clean" | "overlap" | "constraint_flag" | "has_open_designs"`. Only
-   * `"file_overlap"` and `"constraint_violation"` can come back from
+   * `"clean" | "overlap" | "constraint_flag"`. Only `"file_overlap"` and
+   * `"constraint_violation"` can come back from
    * `/v1/designs/check`/`amend`/`resume` (design-checks.ts tiers 1/3);
    * `"symbol_conflict"`/`"llm_divergence"` only ever arise from
    * `/v1/claims` or the async semantic-comparator pass, never this
    * synchronous response. See DesignVerdict's own doc comment,
-   * core/types.ts, for the full four-bucket model. */
-  verdict?: "clean" | "file_overlap" | "constraint_violation" | "has_open_designs";
-  /** Absent only for `"has_open_designs"` -- that verdict fires before any
-   * row is created. See DesignVerdict's own doc comment in core/types.ts. */
+   * core/types.ts, for the full four-bucket model. (A fifth value,
+   * `"has_open_designs"`, existed briefly for this response 2026-08-25 to
+   * 2026-08-31 -- retired, see DesignVerdict's doc comment for why.) */
+  verdict?: "clean" | "file_overlap" | "constraint_violation";
   designId?: string;
   /** §17 design linking (2026-08) -- the design's own groupId, self-assigned
    * or caller-supplied. Copy this into a sibling repo's
@@ -75,10 +106,10 @@ interface DesignCheckResponseJSON {
    * `constraint` object -- see design-checks.ts's matchConstraintsForPaths
    * doc comment for the full reasoning). */
   constraints?: { statement: string; type: string }[];
-  /** Set only for `"has_open_designs"` (2026-08-25, "force a choice"
-   * registration-sprawl fix) -- the developer's other currently-open
-   * designs, cross-project, found before this registration was created. */
-  openDesigns?: { id: string; projectId: string; summary: string; lastActivityAt: number }[];
+  /** Change D (2026-08-31): only ever populated by a successful
+   * `--reassign-project` amend -- the design's new home, echoed back so
+   * `printDesignVerdict` can confirm the move actually happened. */
+  projectId?: string;
 }
 
 async function parseJsonOrUnauthorized<T>(res: Response): Promise<T | { error: string }> {
@@ -91,9 +122,13 @@ function printDesignVerdict(result: DesignCheckResponseJSON): void {
     console.error(`twing design: ${result.error}`);
     return;
   }
-  // "has_open_designs" (2026-08-25) has no designId -- no row exists yet
-  // for this verdict, see DesignCheckResult.designId's own doc comment.
   console.log(`verdict: ${result.verdict}` + (result.designId ? `  design: ${result.designId}` : ""));
+  if (result.projectId) {
+    // Change D (2026-08-31): only a successful --reassign-project amend
+    // sets this -- confirms the move, mirroring Change A's "report what
+    // actually happened" reasoning for ExitPlanMode's own registration.
+    console.log(`  now in project: ${result.projectId}`);
+  }
   if (result.groupId) {
     // §17 design linking (2026-08): the copy-paste hint for linking a
     // sibling-repo registration to this one.
@@ -114,15 +149,6 @@ function printDesignVerdict(result: DesignCheckResponseJSON): void {
       console.log(`  [${c.type}] ${c.statement}`);
     }
     console.log(`  -> adjust your plan, or run: twing design resolve --id ${result.designId} --justify "<reason>" (a project admin will need to approve)`);
-  } else if (result.verdict === "has_open_designs") {
-    // "Force a choice" registration-sprawl fix (2026-08-25): no row was
-    // created for this call -- nothing to point `resolve`/`close` at yet.
-    for (const d of result.openDesigns ?? []) {
-      console.log(`  open: ${d.id}  (project ${d.projectId}) -- "${d.summary || "no summary"}"`);
-    }
-    console.log(`  -> if this is a continuation, link it: twing design register ... --group <id>`);
-    console.log(`  -> if that work is done, close it first: twing design close --id <id>`);
-    console.log(`  -> if this is genuinely new, override: twing design register ... --force`);
   }
 }
 
@@ -138,11 +164,6 @@ export interface RegisterOptions {
    * design (typically in another repo) sharing the same unit of work --
    * pass the `groupId` printed by that design's own registration. */
   group?: string;
-  /** "Force a choice" registration-sprawl fix (2026-08-25): explicit
-   * override of the has-open-designs pre-registration check -- for a
-   * genuinely new, unrelated design registered while another is still
-   * open. See DesignCheckRequestBody.force's doc comment (packages/server). */
-  force?: boolean;
 }
 
 /**
@@ -193,6 +214,8 @@ export async function runDesignRegister(options: RegisterOptions): Promise<void>
   }
 
   const projectId = computeProjectId(repoRoot);
+  const touches = splitList(options.touches);
+  warnIfTouchesMissing(repoRoot, touches);
 
   const res = await authFetch(
     `${serverUrl}/v1/designs/check`,
@@ -206,10 +229,9 @@ export async function runDesignRegister(options: RegisterOptions): Promise<void>
         agentLabel: options.label,
         summary: options.summary ?? "",
         creates: splitList(options.creates),
-        touches: splitList(options.touches),
+        touches,
         dependsOn: splitList(options.dependsOn),
         ...(options.group ? { groupId: options.group } : {}),
-        ...(options.force ? { force: true } : {}),
       }),
     },
     authToken,
@@ -315,6 +337,13 @@ export interface AmendOptions {
    * validated against a real design). Printed back via the shared
    * `group: <id>` hint in `printDesignVerdict`, same as `register`/`check`. */
   group?: string;
+  /** Change D (2026-08-31, design-gate registration-flow fixes): move this
+   * design to the project resolved from `cwd` -- run from the correct
+   * repo, no raw project-id hash to paste, same resolution `register`
+   * already uses. Mutually exclusive with every other field on this
+   * type -- it's a distinct action (`reassignProjectId` server-side), not
+   * a scope amend, and is checked first in `runDesignAmend` below. */
+  reassignProject?: boolean;
 }
 
 /**
@@ -336,9 +365,33 @@ export async function runDesignAmend(options: AmendOptions): Promise<void> {
   if (!options.id) {
     throw new Error("twing design amend: --id <designId> is required");
   }
-  if (!options.touches && !options.creates && !options.dependsOn && !options.summary && !options.group) {
-    throw new Error("twing design amend: pass at least one of --touches, --creates, --depends-on, --summary, --group");
+
+  // Change D: a fix-in-place for a wrong-project registration -- see
+  // AmendOptions.reassignProject's own doc comment for why this is
+  // checked first and is mutually exclusive with every other amend shape.
+  if (options.reassignProject) {
+    if (options.touches || options.creates || options.dependsOn || options.summary || options.group) {
+      throw new Error(
+        "twing design amend: --reassign-project can't be combined with --touches/--creates/--depends-on/--summary/--group -- " +
+          "it's a distinct action (moving the design), run it on its own",
+      );
+    }
+    const newProjectId = computeProjectId(repoRoot);
+    const res = await authFetch(
+      `${serverUrl}/v1/designs/${options.id}/amend`,
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ reassignProjectId: newProjectId }) },
+      authToken,
+      developerId,
+    );
+    printDesignVerdict(await parseJsonOrUnauthorized<DesignCheckResponseJSON>(res));
+    return;
   }
+
+  if (!options.touches && !options.creates && !options.dependsOn && !options.summary && !options.group) {
+    throw new Error("twing design amend: pass at least one of --touches, --creates, --depends-on, --summary, --group, --reassign-project");
+  }
+  const addTouches = splitList(options.touches);
+  warnIfTouchesMissing(repoRoot, addTouches);
 
   const res = await authFetch(
     `${serverUrl}/v1/designs/${options.id}/amend`,
@@ -346,7 +399,7 @@ export async function runDesignAmend(options: AmendOptions): Promise<void> {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        addTouches: splitList(options.touches),
+        addTouches,
         addCreates: splitList(options.creates),
         addDependsOn: splitList(options.dependsOn),
         ...(options.summary ? { summary: options.summary } : {}),
@@ -392,6 +445,9 @@ export async function runDesignResume(options: ResumeOptions): Promise<void> {
     );
   }
 
+  const resumeTouches = splitList(options.touches);
+  warnIfTouchesMissing(repoRoot, resumeTouches);
+
   const res = await authFetch(
     `${serverUrl}/v1/designs/${options.id}/resume`,
     {
@@ -399,7 +455,7 @@ export async function runDesignResume(options: ResumeOptions): Promise<void> {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         sessionId: session,
-        addTouches: splitList(options.touches),
+        addTouches: resumeTouches,
         addCreates: splitList(options.creates),
         addDependsOn: splitList(options.dependsOn),
       }),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -95,9 +95,10 @@ function printUsage(): void {
       "  twing project revoke-invite --code <invite-code> [--server <url>]",
       "  twing project remove-developer --developer-id <id> [--project <id>] [--server <url>]",
       "  twing project list-developers [--project <id>] [--server <url>]",
-      "  twing design register --session <id> --summary \"...\" --creates a,b --touches c,d --depends-on e,f [--group <groupId>] [--force]",
+      "  twing design register --session <id> --summary \"...\" --creates a,b --touches c,d --depends-on e,f [--group <groupId>]",
       "  twing design resolve --id <designId> (--adopt <designId> | --justify \"...\")",
       "  twing design amend --id <designId> [--touches a,b] [--creates c,d] [--depends-on e,f] [--summary \"...\"] [--group <groupId>]",
+      "  twing design amend --id <designId> --reassign-project   (run from the correct repo -- moves an open, unencumbered design there)",
       "  twing design resume --id <designId> [--session <id>] [--touches a,b] [--creates c,d] [--depends-on e,f]",
       "  twing design close --id <designId>",
       "  twing design list [--status open] [--mine]",
@@ -138,14 +139,22 @@ async function runDesignCommand(rest: string[]): Promise<void> {
         touches: flags.touches,
         dependsOn: flags["depends-on"],
         group: flags.group,
-        force: flags.force === "true",
       });
       return;
     case "resolve":
       await runDesignResolve({ cwd, id: flags.id, adopt: flags.adopt, justify: flags.justify });
       return;
     case "amend":
-      await runDesignAmend({ cwd, id: flags.id, touches: flags.touches, creates: flags.creates, dependsOn: flags["depends-on"], summary: flags.summary, group: flags.group });
+      await runDesignAmend({
+        cwd,
+        id: flags.id,
+        touches: flags.touches,
+        creates: flags.creates,
+        dependsOn: flags["depends-on"],
+        summary: flags.summary,
+        group: flags.group,
+        reassignProject: flags["reassign-project"] === "true",
+      });
       return;
     case "resume":
       await runDesignResume({ cwd, id: flags.id, session: flags.session, touches: flags.touches, creates: flags.creates, dependsOn: flags["depends-on"] });

--- a/packages/cli/src/test-support.ts
+++ b/packages/cli/src/test-support.ts
@@ -93,19 +93,23 @@ export function withEnv<T>(vars: Record<string, string | undefined>, run: () => 
   });
 }
 
-export async function captureConsole<T>(run: () => Promise<T>): Promise<{ result: T; logs: string[]; errors: string[] }> {
+export async function captureConsole<T>(run: () => Promise<T>): Promise<{ result: T; logs: string[]; errors: string[]; warnings: string[] }> {
   const logs: string[] = [];
   const errors: string[] = [];
+  const warnings: string[] = [];
   const originalLog = console.log;
   const originalError = console.error;
+  const originalWarn = console.warn;
   console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
   console.error = (...args: unknown[]) => errors.push(args.map(String).join(" "));
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
   try {
     const result = await run();
-    return { result, logs, errors };
+    return { result, logs, errors, warnings };
   } finally {
     console.log = originalLog;
     console.error = originalError;
+    console.warn = originalWarn;
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -323,13 +323,16 @@ export interface DesignConstraint {
  *   them); only ever set via `DesignRegistry.flag()` from the async
  *   comparator pass, after its response has already been sent. Self-
  *   approvable, same reasoning as `"symbol_conflict"`. (Was `"conflict"`.)
- * - `"has_open_designs"`: not actually a conflict between two designs at
- *   all -- a pre-registration hygiene check on one developer (too much of
- *   their own work open at once), running *before* any row exists for
- *   this request. Only reachable from `POST /v1/designs/check`'s
- *   structured (non-`rawPlanText`) path, i.e. `twing design register`,
- *   never `ExitPlanMode` -- see `DesignCheckResult.openDesigns`'s doc
- *   comment.
+ * (There used to be a fifth value, `"has_open_designs"`: not a conflict
+ * between two designs at all, but a pre-registration hygiene check on one
+ * developer having too much of their own work open at once, blocking
+ * *before* any row was created. Retired 2026-08-31 -- found live to break
+ * two normal workflows (mid-session task-switching without plan mode,
+ * concurrent sessions on different repos under the same identity) it never
+ * accounted for. The advisory-only "stale sibling" notice
+ * `DesignRegistry`/`app.ts` already ran for `ExitPlanMode` covers the same
+ * underlying concern -- a developer accumulating forgotten open designs --
+ * without blocking, and now runs for both registration paths.)
  *
  * `DesignSeverity`/`severity` is gone as of this change: with tier 4 and
  * the three-way constraint type both collapsed, whether a verdict blocks
@@ -338,7 +341,7 @@ export interface DesignConstraint {
  * vary independently of its own verdict was dead weight. Every former
  * `severity === "error"` check becomes a static per-verdict table instead.
  */
-export type DesignVerdict = "clean" | "file_overlap" | "constraint_violation" | "symbol_conflict" | "llm_divergence" | "has_open_designs";
+export type DesignVerdict = "clean" | "file_overlap" | "constraint_violation" | "symbol_conflict" | "llm_divergence";
 
 export type DesignOverlapKind = "creates" | "touches" | "constraint" | "symbol";
 
@@ -360,10 +363,7 @@ export interface DesignConflict {
 
 export interface DesignCheckResult {
   verdict: DesignVerdict;
-  /** Absent only for `"has_open_designs"` -- that verdict fires *before* a
-   * row is created (see DesignVerdict's own doc comment), so there is no id
-   * to report yet. Every other verdict always has one. */
-  designId?: string;
+  designId: string;
   conflicts?: DesignConflict[];
   /** Every constraint the checked scope matched (2026-08-22 -- was a single
    * `constraint` object; `matchConstraintsForPaths` used to collapse to one
@@ -372,12 +372,6 @@ export interface DesignCheckResult {
    * only discover the next one on retry. See design-checks.ts's own doc
    * comment on `matchConstraintsForPaths` for the full reasoning. */
   constraints?: { id: string; statement: string; type: DesignConstraintType }[];
-  /** Set only for `"has_open_designs"` (2026-08-25) -- the developer's other
-   * currently-open designs, cross-project, that a plain `twing design
-   * register` call found before creating a new row. Lets the CLI print
-   * "here's what you already have open" without a second round trip. Never
-   * set for any other verdict. */
-  openDesigns?: { id: string; projectId: string; summary: string; lastActivityAt: number }[];
 }
 
 export interface PendingReview {

--- a/packages/server/drizzle/0013_reassign-project-indexes.sql
+++ b/packages/server/drizzle/0013_reassign-project-indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX `alignment_threads_design_id_idx` ON `alignment_threads` (`design_id`);--> statement-breakpoint
+CREATE INDEX `alignment_threads_initiating_design_id_idx` ON `alignment_threads` (`initiating_design_id`);--> statement-breakpoint
+CREATE INDEX `pending_reviews_design_id_idx` ON `pending_reviews` (`design_id`);

--- a/packages/server/drizzle/meta/0013_snapshot.json
+++ b/packages/server/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,971 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f4dbdf7e-6bca-4b3d-8cc5-eb5db6e27a48",
+  "prevId": "d54717a3-4035-4052-b6fa-47b628663006",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_id": {
+          "name": "related_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_events_project_ts_idx": {
+          "name": "activity_events_project_ts_idx",
+          "columns": [
+            "project_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "activity_events_related_id_idx": {
+          "name": "activity_events_related_id_idx",
+          "columns": [
+            "related_id"
+          ],
+          "isUnique": false
+        },
+        "activity_events_kind_idx": {
+          "name": "activity_events_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alignment_threads": {
+      "name": "alignment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol_id": {
+          "name": "symbol_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "other_developer_id": {
+          "name": "other_developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_description": {
+          "name": "system_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sub_kind": {
+          "name": "sub_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol_ids": {
+          "name": "symbol_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "initiating_design_id": {
+          "name": "initiating_design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alignment_threads_project_id_idx": {
+          "name": "alignment_threads_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "alignment_threads_design_id_idx": {
+          "name": "alignment_threads_design_id_idx",
+          "columns": [
+            "design_id"
+          ],
+          "isUnique": false
+        },
+        "alignment_threads_initiating_design_id_idx": {
+          "name": "alignment_threads_initiating_design_id_idx",
+          "columns": [
+            "initiating_design_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "constraints": {
+      "name": "constraints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "constraints_project_id_idx": {
+          "name": "constraints_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "constraints_project_statement_uidx": {
+          "name": "constraints_project_statement_uidx",
+          "columns": [
+            "project_id",
+            "statement"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "designs": {
+      "name": "designs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_label": {
+          "name": "agent_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creates": {
+          "name": "creates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "touches": {
+          "name": "touches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depends_on": {
+          "name": "depends_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_plan_excerpt": {
+          "name": "raw_plan_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttl_ms": {
+          "name": "ttl_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_version": {
+          "name": "scope_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "justified_constraint_ids": {
+          "name": "justified_constraint_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "justified_overlaps": {
+          "name": "justified_overlaps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "justified_conflicts": {
+          "name": "justified_conflicts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "justified_symbol_conflicts": {
+          "name": "justified_symbol_conflicts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "designs_project_id_idx": {
+          "name": "designs_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "designs_session_id_idx": {
+          "name": "designs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "designs_group_id_idx": {
+          "name": "designs_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "developers": {
+      "name": "developers",
+      "columns": {
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "developers_token_hash_unique": {
+          "name": "developers_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_project_id": {
+          "name": "scope_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by": {
+          "name": "consumed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_memberships": {
+      "name": "org_memberships",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_memberships_org_id_developer_id_pk": {
+          "columns": [
+            "org_id",
+            "developer_id"
+          ],
+          "name": "org_memberships_org_id_developer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_reviews": {
+      "name": "pending_reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "constraint_ids": {
+          "name": "constraint_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "overlap_waivers": {
+          "name": "overlap_waivers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "conflict_waivers": {
+          "name": "conflict_waivers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "symbol_conflict_waivers": {
+          "name": "symbol_conflict_waivers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "pending_reviews_project_id_idx": {
+          "name": "pending_reviews_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pending_reviews_design_id_idx": {
+          "name": "pending_reviews_design_id_idx",
+          "columns": [
+            "design_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_memberships": {
+      "name": "project_memberships",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_memberships_project_id_developer_id_pk": {
+          "columns": [
+            "project_id",
+            "developer_id"
+          ],
+          "name": "project_memberships_project_id_developer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_records": {
+      "name": "project_records",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "founded_by": {
+          "name": "founded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roadmap_items": {
+      "name": "roadmap_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roadmap_items_project_id_idx": {
+          "name": "roadmap_items_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1787767415588,
       "tag": "0012_design-blocked-reason",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1788161747241,
+      "tag": "0013_reassign-project-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/activity-log.ts
+++ b/packages/server/src/activity-log.ts
@@ -91,7 +91,15 @@ export type ActivityEventKind =
    * specifically the dormant-thread path, triggered by `design resume`) --
    * this is the closed-thread path, triggered by `findOrCreate` reacting to
    * a fresh finding, not a party's own action. */
-  | "alignment_thread_reopened";
+  | "alignment_thread_reopened"
+  /** Change D (2026-08-31, design-gate registration-flow fixes):
+   * `DesignRegistry.reassignProject` moved an open design into a different
+   * project -- a fix-in-place for a wrong-project registration, guarded to
+   * only ever fire on a design nothing downstream depends on yet (see that
+   * method's own doc comment). Logged under the *new* project; the
+   * design's earlier `design_registered`/`design_checked` rows correctly
+   * stay under the old one, per this table's insert-only convention. */
+  | "design_reassigned";
 
 export interface ActivityEvent {
   id: string;

--- a/packages/server/src/alignment-store.ts
+++ b/packages/server/src/alignment-store.ts
@@ -450,6 +450,27 @@ export class AlignmentThreadStore {
     return row ? fromRow(row) : undefined;
   }
 
+  /** `DesignRegistry.reassignProject`'s guard (Change D, 2026-08-31): a
+   * design already named in a reconciliation thread -- as either the party
+   * whose claim triggered it (`designId`) or the initiator whose own open
+   * design it was checked against (`initiatingDesignId`) -- has real
+   * cross-developer conversation attached under its current project;
+   * moving it out from under that thread would leave the thread's own
+   * `projectId` pointing at a project the design itself no longer belongs
+   * to. Any status (open or closed) counts, matching
+   * `DesignRegistry.hasReviewForDesign`'s same reasoning. Uses the new
+   * `alignment_threads_design_id_idx`/`alignment_threads_initiating_design_id_idx`
+   * (`db/schema.ts`). */
+  hasThreadForDesign(designId: string): boolean {
+    const row = this.db
+      .select({ id: threadsTable.id })
+      .from(threadsTable)
+      .where(or(eq(threadsTable.designId, designId), eq(threadsTable.initiatingDesignId, designId)))
+      .limit(1)
+      .get();
+    return row !== undefined;
+  }
+
   listByProject(projectId: string, status?: AlignmentThread["status"]): AlignmentThread[] {
     const conditions = [eq(threadsTable.projectId, projectId)];
     if (status) conditions.push(eq(threadsTable.status, status));

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -661,7 +661,7 @@ test("GET /v1/activity: newest-first, respects ?limit=, ?before= pages backward,
     await app.request("/v1/designs/check", {
       method: "POST",
       headers: { "content-type": "application/json", ...bearer(admin.token) },
-      body: JSON.stringify({ projectId: "proj-1", sessionId: `s${i}`, summary: summaries[i], creates: [`f${i}.ts`], touches: [], dependsOn: [], force: true }),
+      body: JSON.stringify({ projectId: "proj-1", sessionId: `s${i}`, summary: summaries[i], creates: [`f${i}.ts`], touches: [], dependsOn: [] }),
     });
     await new Promise((resolve) => setTimeout(resolve, 2));
   }
@@ -2211,7 +2211,7 @@ test("GET /v1/designs: newest-first, optionally filtered by status/sessionId", a
     const res = await app.request("/v1/designs/check", {
       method: "POST",
       headers: { "content-type": "application/json", ...bearer(admin.token) },
-      body: JSON.stringify({ projectId: "proj-1", sessionId, summary: `design for ${sessionId}`, creates: [], touches, dependsOn: [], force: true }),
+      body: JSON.stringify({ projectId: "proj-1", sessionId, summary: `design for ${sessionId}`, creates: [], touches, dependsOn: [] }),
     });
     return (await res.json()) as { designId: string; verdict: string };
   };
@@ -2250,7 +2250,7 @@ test("GET /v1/designs: ?limit= paginates with a nextBefore cursor, walking every
     const res = await app.request("/v1/designs/check", {
       method: "POST",
       headers: { "content-type": "application/json", ...bearer(admin.token) },
-      body: JSON.stringify({ projectId: "proj-1", sessionId, summary: sessionId, creates: [], touches: [`${sessionId}.ts`], dependsOn: [], force: true }),
+      body: JSON.stringify({ projectId: "proj-1", sessionId, summary: sessionId, creates: [], touches: [`${sessionId}.ts`], dependsOn: [] }),
     });
     return ((await res.json()) as { designId: string }).designId;
   };
@@ -2298,12 +2298,12 @@ test("GET /v1/designs: ?developerId= filters server-side, so 'mine only' stays c
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "admin's", creates: [], touches: ["a.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "admin's", creates: [], touches: ["a.ts"], dependsOn: [] }),
   });
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(otherPat) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "other's", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "other's", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
 
   const res = await app.request(`/v1/designs?projectId=proj-1&developerId=${admin.developerId}`, { headers: bearer(admin.token) });
@@ -2588,7 +2588,7 @@ test("GET /v1/designs/scope-match: no_design, in_scope, out_of_scope, and flagge
   const flaggedRegisterRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["protected.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["protected.ts"], dependsOn: [] }),
   });
   const { designId: flaggedId, verdict: flaggedVerdict } = (await flaggedRegisterRes.json()) as { designId: string; verdict: string };
   assert.equal(flaggedVerdict, "constraint_violation");
@@ -2634,7 +2634,7 @@ test("GET /v1/designs/scope-match: out_of_scope with more than one open design i
   const secondRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newest task", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newest task", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
   const { designId: secondId } = (await secondRes.json()) as { designId: string };
 
@@ -2700,7 +2700,7 @@ test("POST /v1/designs/check: a flagged design stays visible to a *third* design
   const secondRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "second", creates: [], touches: ["shared.ts", "constrained.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "second", creates: [], touches: ["shared.ts", "constrained.ts"], dependsOn: [] }),
   });
   const secondBody = (await secondRes.json()) as { verdict: string; designId: string };
   assert.equal(secondBody.verdict, "constraint_violation");
@@ -2797,7 +2797,7 @@ test("POST /v1/designs/:id/amend: a groupId-only body joins a group after the fa
   const soloRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "was solo", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "was solo", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
   const solo = (await soloRes.json()) as { designId: string; groupId?: string };
   assert.equal(solo.groupId, solo.designId, "starts as its own group of one");
@@ -2838,7 +2838,7 @@ test("POST /v1/designs/:id/amend: a groupId-only amend never touches conflict de
   const targetRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "target", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "target", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
   const target = (await targetRes.json()) as { designId: string; verdict: string };
   assert.equal(target.verdict, "clean", "sanity: unrelated projects/paths, nothing to conflict with");
@@ -2872,7 +2872,7 @@ test("POST /v1/designs/:id/amend: a groupId-only body still succeeds against a C
   const targetRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "target", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-b", sessionId: "s2", summary: "target", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
   const target = (await targetRes.json()) as { designId: string };
 
@@ -3042,7 +3042,7 @@ test("POST /v1/designs/:id/amend: a rejected amend's proposed scope survives an 
   const registerRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
   });
   const { designId } = (await registerRes.json()) as { designId: string };
 
@@ -3309,7 +3309,7 @@ test("POST /v1/designs/:id/amend: supersedes a still-running semantic-comparator
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(otherPat) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-other2", summary: "", creates: [], touches: ["other2.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-other2", summary: "", creates: [], touches: ["other2.ts"], dependsOn: [] }),
   });
 
   let calls = 0;
@@ -3531,7 +3531,7 @@ test("GET /v1/designs/scope-match: a flagged design takes priority over a dorman
   const flaggedRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "new plan", creates: [], touches: ["protected.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "new plan", creates: [], touches: ["protected.ts"], dependsOn: [] }),
   });
   const { designId: flaggedId, verdict } = (await flaggedRes.json()) as { designId: string; verdict: string };
   assert.equal(verdict, "constraint_violation");
@@ -3569,14 +3569,14 @@ test("GET /v1/designs/scope-match: with more than one flagged design, the one wh
   const olderRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "older", creates: [], touches: ["a-protected.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "older", creates: [], touches: ["a-protected.ts"], dependsOn: [] }),
   });
   const { designId: olderId } = (await olderRes.json()) as { designId: string };
 
   const newerRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newer", creates: [], touches: ["b-protected.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newer", creates: [], touches: ["b-protected.ts"], dependsOn: [] }),
   });
   const { designId: newerId } = (await newerRes.json()) as { designId: string };
 
@@ -3606,7 +3606,7 @@ test("GET /v1/designs/scope-match: dormant fallback picks the newest dormant des
   const secondRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newest task", creates: [], touches: ["b.ts"], dependsOn: [], ttlMs: 10, force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "newest task", creates: [], touches: ["b.ts"], dependsOn: [], ttlMs: 10 }),
   });
   const { designId: secondId } = (await secondRes.json()) as { designId: string };
 
@@ -3814,7 +3814,7 @@ test("POST /v1/designs/check: registering a non-overlapping design for the same 
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "unrelated second task", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "unrelated second task", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
 
   const notices = await app.request("/v1/notices?since=0", { headers: bearer(admin.token) });
@@ -3838,7 +3838,7 @@ test("POST /v1/designs/check: an overlapping second design does not also fire th
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
   });
 
   const notices = await app.request("/v1/notices?since=0", { headers: bearer(admin.token) });
@@ -3868,7 +3868,7 @@ test("POST /v1/designs/check: a non-overlapping design from a *different* sessio
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s2", summary: "", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
 
   const notices = await app.request("/v1/notices?since=0", { headers: bearer(admin.token) });
@@ -4049,7 +4049,7 @@ test("POST /v1/designs/check: a structured (twing design register-style) call wi
   const second = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-cli", summary: "task one", creates: ["A"], touches: [], dependsOn: [], force: true }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-cli", summary: "task one", creates: ["A"], touches: [], dependsOn: [] }),
   });
   const secondBody = (await second.json()) as { designId: string; verdict: string };
   assert.equal(second.status, 200);
@@ -4100,12 +4100,49 @@ test("POST /v1/designs/check: a reregistered design keeps its justifiedConstrain
   assert.equal(secondBody.verdict, "clean", "already-justified constraint must not be re-flagged after a mere retry");
 });
 
+test("POST /v1/designs/check: a pure rawPlanText request (extraction runs server-side) echoes the extracted creates/touches back, for the Go hook's own existence check", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  const extracted = { creates: [], touches: ["src/net/retry.ts"], dependsOn: [], summary: "add retry policy" };
+
+  const res = await withBedrockEnv(() =>
+    withMockFetch(mockBedrockExtraction(extracted), async () =>
+      app.request("/v1/designs/check", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...bearer(admin.token) },
+        body: JSON.stringify({ projectId: "proj-1", sessionId: "s-plan", rawPlanText: "Add a RetryPolicy class to src/net/retry.ts." }),
+      }),
+    ),
+  );
+  const body = (await res.json()) as { verdict: string; creates?: string[]; touches?: string[] };
+  assert.equal(body.verdict, "clean");
+  assert.deepEqual(body.touches, ["src/net/retry.ts"]);
+  assert.deepEqual(body.creates, []);
+});
+
+test("POST /v1/designs/check: a structured (non-rawPlanText) request never echoes creates/touches back -- the caller already has them", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  const res = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "solo", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const body = (await res.json()) as { verdict: string; creates?: string[]; touches?: string[] };
+  assert.equal("touches" in body, false);
+  assert.equal("creates" in body, false);
+});
+
 // ---------------------------------------------------------------------------
-// "Force a choice" registration-sprawl fix (2026-08-25) -- POST
-// /v1/designs/check's pre-registration has_open_designs check.
+// Registration-sprawl handling -- POST /v1/designs/check's cross-project
+// "stale sibling" notice. Was a hard-blocking `has_open_designs` verdict
+// for the structured register path only (2026-08-25); retired 2026-08-31
+// (found live to break normal task-switching and concurrent sessions) in
+// favor of unconditionally registering and nudging instead, the same way
+// ExitPlanMode's rawPlanText path always has.
 // ---------------------------------------------------------------------------
 
-test("POST /v1/designs/check: a structured register call blocks with has_open_designs when the developer already has another open design, and creates no row", async () => {
+test("POST /v1/designs/check: a second structured register call registers cleanly even with another open design elsewhere, and posts a stale-sibling notice", async () => {
   const { app, dataDir, designs } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
 
@@ -4116,89 +4153,235 @@ test("POST /v1/designs/check: a structured register call blocks with has_open_de
   });
   const { designId: firstId } = (await firstRes.json()) as { designId: string };
 
-  const beforeCount = designs.listByProject("proj-1").length;
   const secondRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
     body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "second, different project entirely", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
   assert.equal(secondRes.status, 200);
-  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string; openDesigns?: { id: string }[] };
-  assert.equal(secondBody.verdict, "has_open_designs");
-  assert.equal(secondBody.designId, undefined, "no row exists for this verdict yet");
-  assert.ok(secondBody.openDesigns?.some((d) => d.id === firstId));
-  assert.equal(designs.listByProject("proj-1").length, beforeCount, "no new row persisted anywhere");
-  assert.equal(designs.listByProject("proj-2").length, 0, "no new row persisted anywhere");
+  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string };
+  assert.equal(secondBody.verdict, "clean", "no longer blocked -- registers unconditionally, same as ExitPlanMode always has");
+  assert.ok(secondBody.designId, "a real row is created, unlike the old has_open_designs verdict");
+  assert.equal(designs.listByProject("proj-1").length, 1);
+  assert.equal(designs.listByProject("proj-2").length, 1);
+
+  const activity = await app.request("/v1/activity?projectId=proj-2&kind=design_stale_sibling_suggested", { headers: bearer(admin.token) });
+  const activityBody = (await activity.json()) as { items: { payload?: { newDesignId?: string; staleDesignId?: string } }[] };
+  assert.equal(activityBody.items.length, 1);
+  assert.equal(activityBody.items[0].payload?.staleDesignId, firstId, "nudges about the earlier, still-open sibling by id");
 });
 
-test("POST /v1/designs/check: a caller-supplied groupId skips the has_open_designs block", async () => {
+test("POST /v1/designs/check: two concurrent sessions on different projects never block each other", async () => {
   const { app, dataDir } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
 
   const firstRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "session-a", summary: "session A's ongoing work", creates: [], touches: ["a.ts"], dependsOn: [] }),
   });
-  const { designId: firstId } = (await firstRes.json()) as { designId: string };
-
   const secondRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "linked continuation", creates: [], touches: ["b.ts"], dependsOn: [], groupId: firstId }),
+    body: JSON.stringify({ projectId: "proj-2", sessionId: "session-b", summary: "session B's unrelated ongoing work", creates: [], touches: ["b.ts"], dependsOn: [] }),
   });
-  const secondBody = (await secondRes.json()) as { verdict: string; groupId?: string };
-  assert.notEqual(secondBody.verdict, "has_open_designs");
-  assert.equal(secondBody.groupId, firstId);
+  assert.equal((await firstRes.json() as { verdict: string }).verdict, "clean");
+  assert.equal((await secondRes.json() as { verdict: string }).verdict, "clean");
 });
 
-test("POST /v1/designs/check: force:true skips the has_open_designs block", async () => {
-  const { app, dataDir } = freshApp();
-  const admin = await bootstrapAdmin(app, dataDir);
+// ---------------------------------------------------------------------------
+// Change D (2026-08-31): `POST /v1/designs/:id/amend` with
+// `reassignProjectId` -- fixes a wrong-project registration in place.
+// Scoped narrowly to "nothing downstream depends on this design yet"
+// (status open, no review/thread attached, never linked to a sibling) --
+// see DesignRegistry.reassignProject's own doc comment.
+// ---------------------------------------------------------------------------
 
+test("POST /v1/designs/:id/amend: reassignProjectId moves an open, unencumbered design to a different project the caller is a member of", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  await foundProject(app, admin.token, "proj-1");
+  await foundProject(app, admin.token, "proj-2");
+
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "misfiled under the wrong repo", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId } = (await checkRes.json()) as { designId: string };
+
+  const amendRes = await app.request(`/v1/designs/${designId}/amend`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ reassignProjectId: "proj-2" }),
+  });
+  assert.equal(amendRes.status, 200);
+  const amendBody = (await amendRes.json()) as { verdict: string; designId: string; projectId: string };
+  assert.equal(amendBody.verdict, "clean");
+  assert.equal(amendBody.projectId, "proj-2");
+  assert.equal(designs.get(designId)?.projectId, "proj-2", "the row itself moved");
+  assert.equal(designs.listByProject("proj-1").length, 0);
+  assert.equal(designs.listByProject("proj-2").length, 1);
+
+  const activity = await app.request("/v1/activity?projectId=proj-2&kind=design_reassigned", { headers: bearer(admin.token) });
+  const activityBody = (await activity.json()) as { items: { payload?: { fromProjectId?: string; toProjectId?: string } }[] };
+  assert.equal(activityBody.items.length, 1);
+  assert.deepEqual(activityBody.items[0].payload, { fromProjectId: "proj-1", toProjectId: "proj-2" });
+});
+
+test("POST /v1/designs/:id/amend: reassignProjectId is refused with 403 when the caller isn't a member of the target project, and nothing moves", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  await foundProject(app, admin.token, "proj-1");
+  // proj-2 exists (founded by someone else, via a second identity) but the
+  // admin here was never added to it -- the non-negotiable half of the
+  // auth check: membership in the *old* project alone isn't enough.
+  const otherPat = await makeUnrelatedDeveloper(app, admin, "eve@example.com", "eves-pat");
+  await foundProject(app, otherPat, "proj-2");
+
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "stays put", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId } = (await checkRes.json()) as { designId: string };
+
+  const amendRes = await app.request(`/v1/designs/${designId}/amend`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ reassignProjectId: "proj-2" }),
+  });
+  assert.equal(amendRes.status, 403);
+  assert.equal(designs.get(designId)?.projectId, "proj-1");
+});
+
+test("POST /v1/designs/:id/amend: reassignProjectId is refused with 409 on a non-open design", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  await foundProject(app, admin.token, "proj-1");
+  await foundProject(app, admin.token, "proj-2");
+
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "closed already", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId } = (await checkRes.json()) as { designId: string };
+  await app.request(`/v1/designs/${designId}/close`, { method: "PATCH", headers: bearer(admin.token) });
+
+  const amendRes = await app.request(`/v1/designs/${designId}/amend`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ reassignProjectId: "proj-2" }),
+  });
+  assert.equal(amendRes.status, 409);
+  assert.equal(designs.get(designId)?.projectId, "proj-1");
+});
+
+test("POST /v1/designs/:id/amend: reassignProjectId is refused with 409 once a review has ever been attached, even after approval reopened the design", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  await foundProject(app, admin.token, "proj-1");
+  await foundProject(app, admin.token, "proj-2");
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "a.ts needs sign-off", scope: ["a.ts"] }] }),
+  });
+
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "hits a constraint", creates: ["a.ts"], touches: [], dependsOn: [] }),
+  });
+  const { designId, verdict } = (await checkRes.json()) as { designId: string; verdict: string };
+  assert.equal(verdict, "constraint_violation");
+
+  const resolveRes = await app.request(`/v1/designs/${designId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ resolution: "justified_divergence", justification: "signed off out of band" }),
+  });
+  const { reviewId } = (await resolveRes.json()) as { reviewId: string };
+  const decideRes = await app.request(`/v1/reviews/${reviewId}/decide`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ decision: "approve" }),
+  });
+  assert.equal(decideRes.status, 200);
+  assert.equal(designs.get(designId)?.status, "open", "approval reopens the design -- the guard must still catch it via the review row, not status alone");
+
+  const amendRes = await app.request(`/v1/designs/${designId}/amend`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ reassignProjectId: "proj-2" }),
+  });
+  assert.equal(amendRes.status, 409);
+  assert.equal(designs.get(designId)?.projectId, "proj-1");
+});
+
+test("POST /v1/designs/:id/amend: reassignProjectId is refused with 409 once the design is linked to a sibling via groupId", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+  await foundProject(app, admin.token, "proj-1");
+  await foundProject(app, admin.token, "proj-2");
+  await foundProject(app, admin.token, "proj-3");
+
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "one half of a linked multi-repo plan", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId } = (await checkRes.json()) as { designId: string };
+
+  // A sibling in a third project, explicitly linked via groupId -- same
+  // request shape `twing design register --group <id>` already sends.
   await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-3", sessionId: "s3", summary: "the other half", creates: [], touches: ["b.ts"], dependsOn: [], groupId: designId }),
   });
+  assert.equal(designs.listByGroup(designId).length, 2, "fixture sanity: the two are actually linked");
 
-  const secondRes = await app.request("/v1/designs/check", {
+  const amendRes = await app.request(`/v1/designs/${designId}/amend`, {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-2", sessionId: "s2", summary: "genuinely new", creates: [], touches: ["b.ts"], dependsOn: [], force: true }),
+    body: JSON.stringify({ reassignProjectId: "proj-2" }),
   });
-  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string };
-  assert.notEqual(secondBody.verdict, "has_open_designs");
-  assert.ok(secondBody.designId);
+  assert.equal(amendRes.status, 409);
+  assert.equal(designs.get(designId)?.projectId, "proj-1");
 });
 
-test("POST /v1/designs/check: an ExitPlanMode-shaped (rawPlanText) request is never blocked by has_open_designs, regardless of other open designs", async () => {
-  const { app, dataDir } = freshApp();
+test("POST /v1/designs/:id/amend: reassignProjectId re-checks against the new project's own constraints before persisting -- a non-clean result leaves the design exactly where it was", async () => {
+  const { app, dataDir, designs } = freshApp();
   const admin = await bootstrapAdmin(app, dataDir);
-
-  await app.request("/v1/designs/check", {
+  await foundProject(app, admin.token, "proj-1");
+  await foundProject(app, admin.token, "proj-2");
+  // proj-2 has a constraint that would flag this design's own scope --
+  // clean under proj-1 (no such constraint there), not clean under proj-2.
+  await app.request("/v1/constraints/seed", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "first", creates: [], touches: ["a.ts"], dependsOn: [] }),
+    body: JSON.stringify({ projectId: "proj-2", constraints: [{ statement: "shared.ts needs sign-off", scope: ["shared.ts"] }] }),
   });
 
-  const secondRes = await app.request("/v1/designs/check", {
+  const checkRes = await app.request("/v1/designs/check", {
     method: "POST",
     headers: { "content-type": "application/json", ...bearer(admin.token) },
-    body: JSON.stringify({
-      projectId: "proj-2",
-      sessionId: "s-plan",
-      rawPlanText: "Add a debounce helper to src/ui/search-box.ts so keystrokes don't trigger a network call on every character.",
-      summary: "add debounce helper",
-      creates: [],
-      touches: ["src/ui/search-box.ts"],
-      dependsOn: [],
-    }),
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "clean where it is today", creates: [], touches: ["shared.ts"], dependsOn: [] }),
   });
-  assert.equal(secondRes.status, 200);
-  const secondBody = (await secondRes.json()) as { verdict: string; designId?: string };
-  assert.notEqual(secondBody.verdict, "has_open_designs");
-  assert.ok(secondBody.designId);
+  const { designId, verdict: registerVerdict } = (await checkRes.json()) as { designId: string; verdict: string };
+  assert.equal(registerVerdict, "clean", "fixture sanity: clean under its current project");
+
+  const amendRes = await app.request(`/v1/designs/${designId}/amend`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ reassignProjectId: "proj-2" }),
+  });
+  assert.equal(amendRes.status, 200, "refusal is a 200 with a non-clean verdict, not an HTTP error -- same shape as registration/amend");
+  const amendBody = (await amendRes.json()) as { verdict: string };
+  assert.equal(amendBody.verdict, "constraint_violation");
+  assert.equal(designs.get(designId)?.projectId, "proj-1", "rejected move leaves the design exactly where it was, never landed under proj-2 flagged");
 });
 
 // --- §17 Phase 4: no_auth mode ---

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -67,12 +67,6 @@ interface DesignCheckRequestBody {
   // link label. Optional: self-assigned server-side to this design's own
   // id when omitted. See DesignStatement.groupId (@twing/core).
   groupId?: string;
-  // "Force a choice" registration-sprawl fix (2026-08-25): explicit opt-out
-  // of the has-open-designs pre-registration check below, for a developer
-  // who's deliberately starting a genuinely new, unrelated design while
-  // another is still open. Like groupId, not identity-bearing -- just a
-  // caller-chosen override, never itself a source of authorization.
-  force?: boolean;
 }
 
 interface ResolveRequestBody {
@@ -97,6 +91,14 @@ interface AmendRequestBody {
    * after registration -- see DesignRegistry.amend's `groupId` param doc
    * comment for the full reasoning. */
   groupId?: string;
+  /** Change D (2026-08-31, design-gate registration-flow fixes): move an
+   * open, never-linked, nothing-built-on-it-yet design into a different
+   * project -- fixes a wrong-project registration in place instead of the
+   * only prior options (close-and-reregister, or force-a-duplicate-and-
+   * link). Mutually exclusive with every other field on this body -- see
+   * the route's own handling for why it's checked before the general
+   * scope-amend path, not folded into it. */
+  reassignProjectId?: string;
 }
 
 // §17 design lifecycle (2026-08): sessionId is required -- resume
@@ -1185,30 +1187,25 @@ export function createApp(options: CreateAppOptions = {}) {
         }
       }
     }
-    // "Force a choice" registration-sprawl fix (2026-08-25): before creating
-    // yet another open design, make sure the developer isn't just about to
-    // fragment work they already have open elsewhere. Deliberately scoped to
-    // exactly the structured `twing design register` path -- `ExitPlanMode`
-    // (rawPlanText) always registers unchanged; see this plan's own doc
-    // comment / commit message for why blocking it too would require
-    // guessing at a retry-safe auto-link the way an earlier version of this
-    // feature wrongly did. `groupId`/`force` are the two explicit escape
-    // hatches: a caller who already knows which existing design this
-    // continues, or one deliberately overriding, skips the check entirely.
-    // No row is created if this fires -- unlike file_overlap/
-    // constraint_violation, which register-then-flag, there's nothing yet
-    // worth flagging, so don't create the very clutter this exists to
-    // prevent.
-    if (!body.rawPlanText && !body.groupId && !body.force) {
-      const openForDeveloper = designs.openDesignsForDeveloper(identity.developerId, Date.now());
-      if (openForDeveloper.length > 0) {
-        return c.json({
-          verdict: "has_open_designs",
-          openDesigns: openForDeveloper.map((d) => ({ id: d.id, projectId: d.projectId, summary: d.summary, lastActivityAt: d.lastActivityAt })),
-        });
-      }
-    }
-
+    // "Force a choice" registration-sprawl fix (2026-08-25) retired
+    // 2026-08-31: this used to hard-block a structured `twing design
+    // register` call whenever the developer had any other open design
+    // anywhere, cross-project -- found live to break two completely normal
+    // workflows it never accounted for: switching to an unrelated bug fix
+    // mid-session without going through plan mode (the Edit/Write gate
+    // needs *a* design for the new files, so `register` is the only way to
+    // get one, and this then always fired), and running concurrent
+    // sessions on different repos under the same identity (the check was
+    // purely developerId-scoped, no session/project awareness, so the
+    // second session's first registration collided with the first
+    // session's every time, permanently). `ExitPlanMode` (rawPlanText)
+    // already solved the same underlying problem -- a developer
+    // accumulating forgotten open designs -- without blocking, via the
+    // "stale sibling" notice just below: register unconditionally, then
+    // nudge if a genuinely non-overlapping sibling is still open. That
+    // notice was never conditioned on how registration got here, so
+    // removing this block is enough on its own to give the structured
+    // `register` path the exact same non-blocking behavior for free.
     design ??= designs.register({
       projectId: body.projectId,
       developerId: identity.developerId,
@@ -1287,9 +1284,14 @@ export function createApp(options: CreateAppOptions = {}) {
     // `openDesignsForDeveloper` -- cross-project and no longer
     // session-restricted (session-scoping was only ever load-bearing for an
     // earlier, abandoned ExitPlanMode-blocking approach; see this feature's
-    // plan/commit message). This is `ExitPlanMode`'s entire half of that
-    // feature: it never blocks, it just gets a wider, more useful version of
-    // this same notice.
+    // plan/commit message). This was originally `ExitPlanMode`'s
+    // never-blocking half of that feature, with a separate hard-blocking
+    // `has_open_designs` verdict for the structured `register` path above.
+    // That block was retired 2026-08-31 -- found live to break normal
+    // task-switching and concurrent sessions (see the removed code's git
+    // history for the incident) -- so this notice is now the *entire*
+    // feature for both paths: registration never blocks on this, it just
+    // nudges.
     //
     // Deliberately `pathsOverlap`, not `outcome.conflicts` (2026-08-22): a
     // same-developer sibling is the same developer by construction, and
@@ -1323,8 +1325,19 @@ export function createApp(options: CreateAppOptions = {}) {
     // groupId (§17 design linking, 2026-08): echoed back on every branch --
     // post self-assignment, this is what lets a CLI caller that didn't pass
     // --group still see the value to hand a sibling-repo registration.
+    //
+    // Existence-check advisory (2026-08-31): `creates`/`touches` echoed back
+    // too, but only for a `rawPlanText` (ExitPlanMode) caller -- a
+    // structured `register` call already supplied these itself, so echoing
+    // them back would be pure noise. The Go hook has no other way to see
+    // what design-extract.ts resolved server-side (extraction never
+    // reaches the caller otherwise), and needs exactly this to stat
+    // `touches` against its own local `repoRoot` and warn on a likely
+    // wrong-project registration -- see hook/design_gate.go's
+    // `handleExitPlanModeSingle`.
+    const extractedFields = body.rawPlanText ? { creates: design.creates, touches: design.touches } : {};
     if (outcome.verdict === "clean") {
-      return c.json({ verdict: "clean", designId: design.id, groupId: design.groupId });
+      return c.json({ verdict: "clean", designId: design.id, groupId: design.groupId, ...extractedFields });
     }
     if (outcome.verdict === "constraint_violation") {
       return c.json({
@@ -1332,9 +1345,10 @@ export function createApp(options: CreateAppOptions = {}) {
         designId: design.id,
         groupId: design.groupId,
         constraints: outcome.constraints,
+        ...extractedFields,
       });
     }
-    return c.json({ verdict: "file_overlap", designId: design.id, groupId: design.groupId, conflicts: outcome.conflicts });
+    return c.json({ verdict: "file_overlap", designId: design.id, groupId: design.groupId, conflicts: outcome.conflicts, ...extractedFields });
   });
 
   // §17.5: adopt the conflicting design (superseded), or justify diverging
@@ -1532,6 +1546,61 @@ export function createApp(options: CreateAppOptions = {}) {
     }
 
     const body = await c.req.json<AmendRequestBody>().catch(() => null);
+
+    // Change D (2026-08-31, design-gate registration-flow fixes): move an
+    // open, never-linked, nothing-built-on-it-yet design into a different
+    // project -- checked before every other branch below, since it's a
+    // distinct action with its own guard, not a scope amend. Auth is
+    // non-negotiable: membership in *both* the old project (already
+    // checked above) and the new one, or this would be exactly the hole a
+    // naive version of this feature opens -- moving a design into or out
+    // of a project you're not a member of.
+    if (body?.reassignProjectId !== undefined) {
+      const newProjectId = body.reassignProjectId;
+      if (!isProjectMember(identity, newProjectId)) {
+        return c.json({ error: "not a member of the target project" }, 403);
+      }
+      if (design.status !== "open") {
+        return c.json({ error: `design is ${design.status}, not open -- can't reassign` }, 409);
+      }
+      // Scoped narrowly to "nothing downstream depends on this design
+      // yet" rather than a general move-at-any-point feature -- any of
+      // these three existing means real process has already happened
+      // against the design's *current* project, and the deny message
+      // (hook/design_gate.go's warnIfTouchesMissing) already tells the
+      // caller to close-and-re-register instead when this is refused.
+      if (designs.hasReviewForDesign(id)) {
+        return c.json({ error: "design has a review attached -- close and re-register instead of reassigning" }, 409);
+      }
+      if (alignmentThreads.hasThreadForDesign(id)) {
+        return c.json({ error: "design has an alignment thread attached -- close and re-register instead of reassigning" }, 409);
+      }
+      if (design.groupId && designs.listByGroup(design.groupId).length > 1) {
+        return c.json({ error: "design is linked to another design -- close and re-register instead of reassigning" }, 409);
+      }
+
+      // Re-run the full syntactic check against the *new* project's own
+      // open designs/constraints before persisting anything -- the design
+      // needs to be evaluated against where it would actually live, not
+      // silently trusted. Unlike scope-amend's persist-then-flag (this
+      // route, below), a non-clean verdict here leaves the design exactly
+      // where it was: the guard above already established nothing depends
+      // on this design's current state, so there's nothing to lose by
+      // simply refusing the move outright rather than landing it under
+      // the new project already flagged.
+      const openInNewProject = designs.openDesigns(newProjectId, Date.now(), design.id);
+      const constraintsInNewProject = constraintStore.forProject(newProjectId);
+      const outcome = runDesignChecks(design, openInNewProject, constraintsInNewProject);
+      if (outcome.verdict !== "clean") {
+        console.log(`twing serve: design ${id.slice(0, 8)} reassign to project ${newProjectId.slice(0, 12)} refused -> ${outcome.verdict}`);
+        return c.json({ verdict: outcome.verdict, designId: id, conflicts: outcome.conflicts, constraints: outcome.constraints });
+      }
+
+      const reassigned = designs.reassignProject(id, newProjectId);
+      if (!reassigned) return c.json({ error: "no such design" }, 404);
+      console.log(`twing serve: design ${id.slice(0, 8)} reassigned ${design.projectId.slice(0, 12)} -> ${newProjectId.slice(0, 12)}`);
+      return c.json({ verdict: "clean", designId: reassigned.id, projectId: reassigned.projectId });
+    }
 
     // §17 design linking follow-up (2026-08-28): a groupId-only delta (no
     // scope or summary change) is pure metadata, not a scope expansion --

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -222,7 +222,14 @@ export const pendingReviews = sqliteTable(
      * See PendingReview.symbolConflictWaivers. */
     symbolConflictWaivers: text("symbol_conflict_waivers").notNull().default("[]"),
   },
-  (t) => [index("pending_reviews_project_id_idx").on(t.projectId)],
+  (t) => [
+    index("pending_reviews_project_id_idx").on(t.projectId),
+    // Change D (2026-08-31, design-gate registration-flow fixes): the
+    // `--reassign-project` guard reads "does any pending review reference
+    // this design" on every reassignment attempt -- unindexed, this was a
+    // full table scan.
+    index("pending_reviews_design_id_idx").on(t.designId),
+  ],
 );
 
 export const constraints = sqliteTable(
@@ -298,7 +305,15 @@ export const alignmentThreads = sqliteTable(
     initiatingDesignId: text("initiating_design_id"), // the initiating developer's own open design, when one resolves
     lastActivityAt: integer("last_activity_at"), // bumped on amend; falls back to openedAt when null
   },
-  (t) => [index("alignment_threads_project_id_idx").on(t.projectId)],
+  (t) => [
+    index("alignment_threads_project_id_idx").on(t.projectId),
+    // Change D (2026-08-31): the `--reassign-project` guard also checks
+    // both of a design's thread roles (party's own design, and the
+    // initiator's) -- same reasoning as pending_reviews_design_id_idx
+    // above.
+    index("alignment_threads_design_id_idx").on(t.designId),
+    index("alignment_threads_initiating_design_id_idx").on(t.initiatingDesignId),
+  ],
 );
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/design-store.ts
+++ b/packages/server/src/design-store.ts
@@ -513,6 +513,49 @@ export class DesignRegistry {
     return this.get(id);
   }
 
+  /** Change D (2026-08-31, design-gate registration-flow fixes):
+   * `twing design amend --id <id> --reassign-project`'s persist step --
+   * fixes a design filed under the wrong project in place, instead of the
+   * only prior options (close-and-reregister, or force-a-duplicate-and-
+   * link) for what's usually a single misfiled row. Deliberately narrow:
+   * the route (`/v1/designs/:id/amend` in app.ts) only calls this once its
+   * own guard has confirmed the design is `"open"`, has no
+   * `pendingReviews`/`alignmentThreads` referencing it, and has never
+   * actually been linked to a sibling (`listByGroup(existing.groupId)`
+   * returns only itself) -- moving a design nothing downstream depends on
+   * yet carries none of the cross-row consistency risk a general
+   * move-at-any-point feature would. Metadata-only otherwise, same shape
+   * as `relink`: no scope/verdict re-check happens *here* -- the caller
+   * re-runs `runDesignChecks` against the new project's own open designs
+   * before ever calling this, same "reject and leave existing state
+   * untouched" contract every other amend-family method in this class
+   * follows. `groupId` is left untouched deliberately: a project
+   * reassignment doesn't change the design's own identity, and the "never
+   * linked" guard above already means it only ever equals `id` itself at
+   * this point anyway. Returns `undefined` only if the design doesn't
+   * exist. */
+  reassignProject(id: string, newProjectId: string): DesignStatement | undefined {
+    const existing = this.get(id);
+    if (!existing) return undefined;
+    const oldProjectId = existing.projectId;
+    this.db.update(designsTable).set({ projectId: newProjectId }).where(eq(designsTable.id, id)).run();
+    // Logged under the *new* project -- matches every other activity event
+    // for this design going forward, and this repo's insert-only
+    // convention means the design's earlier `design_registered`/
+    // `design_checked` rows correctly stay under the old project, an
+    // honest record of where it actually lived at the time.
+    this.activityLog.append({
+      projectId: newProjectId,
+      developerId: existing.developerId,
+      sessionId: existing.sessionId,
+      kind: "design_reassigned",
+      relatedId: id,
+      ts: Date.now(),
+      payload: { fromProjectId: oldProjectId, toProjectId: newProjectId },
+    });
+    return this.get(id);
+  }
+
   /** §17 design lifecycle (2026-08): reactivates a *dormant* design, always
    * as an explicit, deliberate act -- never called silently by a mere file
    * match (see `/v1/designs/scope-match`'s `"dormant"` state and the
@@ -905,6 +948,17 @@ export class DesignRegistry {
   getReview(id: string): PendingReview | undefined {
     const row = this.db.select().from(reviewsTable).where(eq(reviewsTable.id, id)).get() as ReviewRow | undefined;
     return row ? fromReviewRow(row) : undefined;
+  }
+
+  /** Change D's `--reassign-project` guard: any review at all (pending or
+   * already decided) referencing this design means real downstream
+   * process has already happened against its current project -- a
+   * reassignment is refused, not just for a still-pending one. Uses the
+   * new `pending_reviews_design_id_idx` (`db/schema.ts`) rather than the
+   * unindexed full-table scan this would otherwise be. */
+  hasReviewForDesign(designId: string): boolean {
+    const row = this.db.select({ id: reviewsTable.id }).from(reviewsTable).where(eq(reviewsTable.designId, designId)).limit(1).get();
+    return row !== undefined;
   }
 
   /** twing-monitor v1: `filter` used to be a `pendingOnly` boolean --


### PR DESCRIPTION
## What

Fixes four related structural gaps in the design gate's cross-project registration flow, found while investigating a stale Reviews pill count in twing-monitor: `ExitPlanMode`'s auto-registration resolved a plan's project from the session's cwd rather than what the plan actually touched, silently filing a design under the wrong repo with zero feedback.

- **`ExitPlanMode` success feedback** — reports what it registered and for which project via `additionalContext`, instead of being completely silent.
- **Retire `has_open_designs`** — manual `design register`'s cross-project hard block broke normal task-switching and concurrent sessions on different repos. The existing "stale sibling" advisory notice now covers both the `ExitPlanMode` and manual registration paths.
- **Existence-check advisory** — a design whose declared `touches` don't exist under the repo root gets a non-blocking warning suggesting `--reassign-project` (wrong repo) or `--group` (genuinely multi-repo plan). CLI-side (`fs.existsSync`, immediate) and `ExitPlanMode`-side (the server echoes extracted `creates`/`touches` back for `rawPlanText` requests, the Go hook stats them against the repo root).
- **`twing design amend --id <id> --reassign-project`** — fixes a misfiled design in place instead of close-and-reregister or force-a-duplicate. Scoped narrowly to an open design with no reviews/threads/links attached; requires membership in both the old and new project; re-runs the full conflict/constraint check against the new project before persisting.

## Verification

- `npm run build && npm run test` (409/409) and `go test ./...` all pass.
- Real end-to-end smoke test: a compiled `twing-hook` binary driven via stdin exactly as Claude Code's hook runner does, against a live `twing serve` backed by real GCP Vertex AI extraction — reproduced the original incident (misfiled plan → existence-check advisory fires with both suggested commands), then `--reassign-project` actually moved the design, confirmed gone from the old project and present in the new one.
- Confirmed cross-project concurrent registration no longer hard-blocks, with the stale-sibling advisory still firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
