### PR TITLE
README: give non-GitHub onboarding its own heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,10 +320,11 @@ export TWING_BIFROST_API_KEY=...            # optional; sk-bf-* sent as x-bf-vk,
 # export TWING_BIFROST_EXTRACT_MODEL=openai/gpt-4o-mini       # default
 ```
 
-**Onboarding a non-GitHub-hosted project** (GitLab, self-hosted git, no
-remote at all) on a full-auth server -- or founding/inviting on your own
-full-auth server generally, since the bootstrap token is filesystem-gated
-and only the operator has it:
+#### Onboarding a non-GitHub-hosted project
+
+(GitLab, self-hosted git, no remote at all) on a full-auth server -- or
+founding/inviting on your own full-auth server generally, since the
+bootstrap token is filesystem-gated and only the operator has it:
 
 **1. Claim the first admin identity**, once per server, from whoever has
 shell access to the machine `twing serve` runs on:


### PR DESCRIPTION
Small follow-up to #14: `Onboarding a non-GitHub-hosted project` was bold inline text with no structural distinction from the surrounding config-block prose, easy to skim past. Promoted to a `####` heading, nested under "Your own public, full-auth server."

🤖 Generated with [Claude Code](https://claude.com/claude-code)