### PR TITLE
README: promote non-GitHub onboarding to a top-level ### heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ export TWING_BIFROST_API_KEY=...            # optional; sk-bf-* sent as x-bf-vk,
 # export TWING_BIFROST_EXTRACT_MODEL=openai/gpt-4o-mini       # default
 ```
 
-#### Onboarding a non-GitHub-hosted project
+### Onboarding a non-GitHub-hosted project
 
 (GitLab, self-hosted git, no remote at all) on a full-auth server -- or
 founding/inviting on your own full-auth server generally, since the


### PR DESCRIPTION
Follow-up to #15: `Onboarding a non-GitHub-hosted project` was nested as `####` under "Your own public, full-auth server", still too buried. Promoted to `###`, a sibling of "Local, or a small trusted team" and "Your own public, full-auth server" -- prominent, but still correctly scoped under 'Self-hosting your own coordinator' since it depends on full-auth-only concepts (bootstrap token, admin identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)