### PR TITLE
Register the project on a no-auth coordinator during twing init

### DIFF
--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -20,6 +20,7 @@ import {
   tmpRepo,
   withHome,
   cacheToken,
+  cacheNoAuth,
   addGithubRemote,
   withMockFetch,
   captureConsole,
@@ -363,5 +364,50 @@ test("runInit: --no-github skips the membership check even for a GitHub-hosted r
     cacheToken(SERVER_URL, "already-cached-pat");
     await captureConsole(() => withMockFetch(fetch, () => runInit({ cwd: repo, server: SERVER_URL, noGithub: true }, deps)));
     assert.ok(!calls.some((c) => c.includes("/v1/auth/whoami")), "--no-github must skip the membership check entirely");
+  });
+});
+
+/** A fetch mock that records each request's URL and its `X-Twing-Developer-Id`
+ * header -- `routedFetch`/`captureFetch` only expose URLs/bodies, and the
+ * no-auth registration path needs the header asserted. Responds "twing
+ * serve" to the reachability probe and `{ seeded: 0 }` to `/v1/constraints/
+ * seed`; throws on anything else. */
+function headerCapturingFetch(): { fetch: typeof fetch; calls: { url: string; developerId: string | null }[] } {
+  const calls: { url: string; developerId: string | null }[] = [];
+  const impl = (async (url: string | URL, init?: RequestInit) => {
+    const u = String(url);
+    calls.push({ url: u, developerId: new Headers(init?.headers).get("x-twing-developer-id") });
+    if (/\/$/.test(u)) return textResponse("twing serve");
+    if (/\/v1\/constraints\/seed$/.test(u)) return jsonResponse({ seeded: 0 });
+    throw new Error(`headerCapturingFetch: no route for ${u}`);
+  }) as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+test("runInit: --no-auth with an empty manifest still calls /v1/constraints/seed to register the project", async () => {
+  const { fetch, calls } = headerCapturingFetch();
+  const { deps } = fakeDeps();
+  await withHome(async () => {
+    const repo = tmpRepo(); // no GitHub remote, empty .twing/twing.yml
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runInit({ cwd: repo, server: SERVER_URL, noAuth: true }, deps)));
+
+    const seed = calls.find((c) => /\/v1\/constraints\/seed$/.test(c.url));
+    assert.ok(seed, "no-auth init must register the project even with nothing to seed");
+    assert.ok(seed!.developerId && seed!.developerId.length > 0, "the seed call must carry a self-declared X-Twing-Developer-Id header");
+    assert.ok(logs.some((l) => l.includes("registered this repo with the coordinator")));
+  });
+});
+
+test("runInit: a second plain `twing init` against an already-cached no-auth server still fires the registration call", async () => {
+  const { fetch, calls } = headerCapturingFetch();
+  const { deps } = fakeDeps();
+  await withHome(async () => {
+    const repo = tmpRepo();
+    cacheNoAuth(SERVER_URL); // as if a prior `twing init --no-auth` ran here
+    await captureConsole(() => withMockFetch(fetch, () => runInit({ cwd: repo, server: SERVER_URL }, deps)));
+    assert.ok(
+      calls.some((c) => /\/v1\/constraints\/seed$/.test(c.url)),
+      "the sticky no-auth flag must be read back so registration still runs without --no-auth on the re-run",
+    );
   });
 });

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -139,6 +139,11 @@ export async function runInit(options: InitOptions, deps: InitDeps = defaultInit
   // Self-declared, attribution-only (§17 Phase 4) -- only ever sent when
   // there's no real token, i.e. only reaches the wire on a no_auth server.
   const developerId = computeDeveloperId(repoRoot);
+  // Read the effective (possibly just-cached above, or set by an earlier
+  // run) no-auth flag -- so a later plain `twing init` against an
+  // already-cached no_auth server still forces the registration call in
+  // `seedConstraints` even when this repo's manifest is empty.
+  const noAuth = getServerAuth(readConfig(), serverUrl)?.noAuth === true;
 
   const hookPath = await deps.ensureHookInstalled();
   console.log(`twing init: hook installed at ${hookPath}`);
@@ -188,7 +193,7 @@ export async function runInit(options: InitOptions, deps: InitDeps = defaultInit
   const daemonStatus = await deps.ensureDaemonRunning();
   console.log(daemonStatus === "started" ? "twing init: daemon started" : "twing init: daemon already running");
 
-  await seedConstraints(repoRoot, manifest, serverUrl, authToken, developerId);
+  await seedConstraints(repoRoot, manifest, serverUrl, authToken, developerId, noAuth);
 
   console.log("twing init: done");
 }
@@ -287,8 +292,19 @@ async function resolveAuthToken(repoRoot: string, serverUrl: string, options: In
  * `authToken` is `undefined` on a `--no-auth` server (§17 Phase 4) --
  * `developerId` (self-declared, attribution only) travels instead. This is
  * also the one call that forwards `githubBinding` (§17 Phase 3) -- the
- * founding trigger, so it's the only place that needs to. */
-async function seedConstraints(repoRoot: string, manifest: Manifest, serverUrl: string, authToken: string | undefined, developerId: string): Promise<void> {
+ * founding trigger, so it's the only place that needs to.
+ * `noAuth` (§17 Phase 4): on a no-auth coordinator this call is *also* the
+ * only thing that registers the repo as a project -- no invite/keygen/
+ * GitHub founding path runs there -- so it must fire even with an empty
+ * manifest and no GitHub binding. */
+async function seedConstraints(
+  repoRoot: string,
+  manifest: Manifest,
+  serverUrl: string,
+  authToken: string | undefined,
+  developerId: string,
+  noAuth: boolean,
+): Promise<void> {
   // §17.9 fix, 2026-08-11: require_human_review entries were silently never
   // forwarded here -- only `constraints:` was. That's the section meant to
   // hold rules like "packages/server/** needs sign-off," and it was never
@@ -300,7 +316,9 @@ async function seedConstraints(repoRoot: string, manifest: Manifest, serverUrl: 
   // this phase, since nothing else needed it to run. Now it's also the one
   // call that establishes a project's GitHub binding at founding time, so
   // it can't stay silent just because there's nothing else to seed.
-  if (manifest.constraints.length === 0 && reviewRules.length === 0 && !github) return;
+  // §17 Phase 4: and on a no-auth coordinator it's the *only* thing that
+  // registers the project at all, so it fires there regardless.
+  if (manifest.constraints.length === 0 && reviewRules.length === 0 && !github && !noAuth) return;
 
   const projectId = computeProjectId(repoRoot);
   try {
@@ -329,7 +347,12 @@ async function seedConstraints(repoRoot: string, manifest: Manifest, serverUrl: 
     );
     if (res.ok) {
       const body = (await res.json()) as { seeded?: number };
-      console.log(`twing init: seeded ${body.seeded ?? manifest.constraints.length + reviewRules.length} constraint(s) into the coordinator (§17)`);
+      const seeded = body.seeded ?? manifest.constraints.length + reviewRules.length;
+      console.log(
+        seeded === 0
+          ? "twing init: registered this repo with the coordinator (no constraints to seed yet) (§17)"
+          : `twing init: seeded ${seeded} constraint(s) into the coordinator (§17)`,
+      );
     } else {
       // Found live, 2026-08-18: this used to always guess "older server, or
       // /v1/designs/* not deployed yet" -- actively misleading for the real

--- a/packages/cli/src/test-support.ts
+++ b/packages/cli/src/test-support.ts
@@ -70,6 +70,15 @@ export function cacheToken(serverUrl: string, token: string): void {
   fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ servers: { [serverUrl]: { authToken: token } } }));
 }
 
+/** §17 Phase 4 counterpart to `cacheToken`: marks `serverUrl` as a no-auth
+ * coordinator in the current $HOME's config.json (no token, `noAuth: true`)
+ * -- must be called after `withHome` has repointed $HOME. */
+export function cacheNoAuth(serverUrl: string): void {
+  const configDir = path.join(os.homedir(), ".twing");
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ servers: { [serverUrl]: { noAuth: true } } }));
+}
+
 export function withMockFetch<T>(impl: typeof fetch, run: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
   globalThis.fetch = impl;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -4462,6 +4462,97 @@ test("no_auth mode: role-gated routes (review decide) succeed regardless of \"ro
   assert.equal(decideRes.status, 200, "no_auth must not require project-admin role for review decisions");
 });
 
+test("no_auth mode: /v1/constraints/seed founds a ProjectRecord attributed to X-Twing-Developer-Id, with the GitHub binding from the body", async () => {
+  const { app, identities } = freshNoAuthApp();
+  const res = await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...developerHeader("dev@example.com") },
+    body: JSON.stringify({ projectId: "proj-na", githubOwner: "acme", githubRepo: "widgets", constraints: [] }),
+  });
+  assert.equal(res.status, 200);
+
+  assert.equal(identities.isProjectFounded("proj-na"), true, "the seed call must register the project on a no_auth coordinator");
+  const record = identities.getProjectRecord("proj-na");
+  assert.equal(record?.foundedBy, "dev@example.com", "foundedBy is the self-declared developer id");
+  assert.equal(record?.githubOwner, "acme");
+  assert.equal(record?.githubRepo, "widgets");
+  assert.equal(record?.orgId, undefined, "a no_auth-founded project has no org");
+});
+
+test("no_auth mode: GET /v1/projects lists every founded project with its GitHub binding", async () => {
+  const { app, identities } = freshNoAuthApp();
+  const dev = developerHeader("dev@example.com");
+
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...dev },
+    body: JSON.stringify({ projectId: "proj-na", githubOwner: "acme", githubRepo: "widgets", constraints: [] }),
+  });
+  await app.request("/v1/claims", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...dev },
+    body: JSON.stringify({ projectId: "proj-na2", claims: [] }),
+  });
+
+  const res = await app.request("/v1/projects", { headers: { ...dev } });
+  assert.equal(res.status, 200);
+  const { items } = (await res.json()) as { items: { projectId: string; githubOwner?: string; foundedBy?: string; role: string }[] };
+  assert.equal(items.length, 2, "both founded projects are listed on a no_auth coordinator");
+
+  const na = items.find((p) => p.projectId === "proj-na");
+  assert.equal(na?.githubOwner, "acme");
+  assert.equal(na?.foundedBy, "dev@example.com");
+  assert.equal(na?.role, "admin", "no_auth reports a flat admin capability");
+  const na2 = items.find((p) => p.projectId === "proj-na2");
+  assert.equal(na2?.githubOwner, undefined, "a project founded via a bare /v1/claims call has no GitHub binding");
+
+  assert.equal(identities.listAllProjectRecords().length, 2);
+});
+
+test("no_auth mode: re-seeding an already-founded project is idempotent -- one record, original founder kept", async () => {
+  const { app, identities } = freshNoAuthApp();
+
+  const first = await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...developerHeader("first@example.com") },
+    body: JSON.stringify({ projectId: "proj-na", githubOwner: "acme", githubRepo: "widgets", constraints: [] }),
+  });
+  assert.equal(first.status, 200);
+
+  const second = await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...developerHeader("second@example.com") },
+    body: JSON.stringify({ projectId: "proj-na", constraints: [{ statement: "x", scope: ["a.ts"], type: "constraint" }] }),
+  });
+  assert.equal(second.status, 200);
+
+  assert.equal(identities.listAllProjectRecords().filter((r) => r.projectId === "proj-na").length, 1);
+  assert.equal(identities.getProjectRecord("proj-na")?.foundedBy, "first@example.com", "founding is one-shot -- the first caller stays the founder");
+});
+
+test("no_auth mode: a bare /v1/claims call founds the project with no GitHub binding", async () => {
+  const { app, identities } = freshNoAuthApp();
+  const res = await app.request("/v1/claims", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...developerHeader("dev@example.com") },
+    body: JSON.stringify({ projectId: "p-claims", claims: [] }),
+  });
+  assert.equal(res.status, 200);
+  assert.equal(identities.isProjectFounded("p-claims"), true);
+  assert.equal(identities.getProjectRecord("p-claims")?.githubOwner, undefined);
+});
+
+test("no_auth mode: /v1/designs/check founds the project", async () => {
+  const { app, identities } = freshNoAuthApp();
+  const res = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...developerHeader("dev@example.com") },
+    body: JSON.stringify({ projectId: "p-design", sessionId: "s1", summary: "", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  assert.equal(res.status, 200);
+  assert.equal(identities.isProjectFounded("p-design"), true);
+});
+
 // --- §17 Phase 3: GitHub-verified project join ---
 
 function mockGithubRepoResponse(permissions: Record<string, boolean>): typeof fetch {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -357,6 +357,23 @@ export function createApp(options: CreateAppOptions = {}) {
   // method needed, getProjectRecord already exists.
   app.get("/v1/projects", (c) => {
     const identity = c.get("identity");
+    // §17 Phase 4: a no_auth identity has no per-caller memberships
+    // (identity.projects is always []), so list every founded project
+    // instead -- there's no cross-org isolation to preserve on a no_auth
+    // coordinator. role is reported "admin" to match no_auth's flat
+    // capability model (canManageProject returns true for everyone here).
+    if (noAuth) {
+      const items = identities.listAllProjectRecords().map((record) => ({
+        projectId: record.projectId,
+        orgId: record.orgId,
+        role: "admin" as const,
+        foundedBy: record.foundedBy,
+        foundedAt: record.foundedAt,
+        githubOwner: record.githubOwner,
+        githubRepo: record.githubRepo,
+      }));
+      return c.json({ items });
+    }
     const items = identity.projects.map((membership) => {
       const record = identities.getProjectRecord(membership.projectId);
       return {
@@ -532,7 +549,18 @@ export function createApp(options: CreateAppOptions = {}) {
     projectId: string,
     github?: { owner: string; repo: string },
   ): { ok: true } | { ok: false; status: 403; error: string } {
-    if (noAuth) return { ok: true };
+    if (noAuth) {
+      // §17 Phase 4: no identity tables exist to found from the normal way
+      // (foundProject needs an org row, foundProjectViaGithub needs a token
+      // + GitHub check), but the project still has to get a record so it
+      // shows up in GET /v1/projects and carries its GitHub binding. Every
+      // project-scoped route reaches here, so this is the same lazy-founding
+      // breadth the authed path gets below. Idempotent via isProjectFounded.
+      if (!identities.isProjectFounded(projectId)) {
+        identities.foundProjectNoAuth(projectId, identity.developerId, github);
+      }
+      return { ok: true };
+    }
     if (identity.projects.some((p) => p.projectId === projectId)) return { ok: true };
     if (!identities.isProjectFounded(projectId)) {
       const founded = identities.foundProject(projectId, identity.developerId, github);

--- a/packages/server/src/identity-store.ts
+++ b/packages/server/src/identity-store.ts
@@ -488,6 +488,19 @@ export class IdentityStore {
     return { ...row, orgId: row.orgId ?? undefined, githubOwner: row.githubOwner ?? undefined, githubRepo: row.githubRepo ?? undefined };
   }
 
+  /** Every project record on this coordinator, unscoped. Only for the §17
+   * Phase 4 no_auth `GET /v1/projects` listing, which has no per-caller
+   * membership to filter by (the no_auth identity's `projects` is always
+   * `[]`). Never call this on the authed path -- it would leak project ids
+   * across orgs. */
+  listAllProjectRecords(): ProjectRecord[] {
+    return this.db
+      .select()
+      .from(projectRecordsTable)
+      .all()
+      .map((row) => ({ ...row, orgId: row.orgId ?? undefined, githubOwner: row.githubOwner ?? undefined, githubRepo: row.githubRepo ?? undefined }));
+  }
+
   /** §boundary-1: the first PAT-holding developer to touch a never-seen
    * `projectId` founds it, attached to their own org, and becomes its
    * project-admin. `github` (§17 Phase 3) is best-effort, forwarded only by
@@ -591,6 +604,43 @@ export class IdentityStore {
       .run();
     this.db.insert(projectMembershipsTable).values({ projectId, developerId, role: "admin" }).run();
     return { developerId };
+  }
+
+  /**
+   * §17 Phase 4 no_auth founding: a `--no-auth` coordinator populates no
+   * identity tables at all, so neither `foundProject` (needs an
+   * org-membership row for the founder) nor `foundProjectViaGithub` (needs a
+   * token/tokenHash + a live GitHub permission check) can run. This is the
+   * no_auth equivalent: founds a bare `project_records` row straight from
+   * the self-declared `developerId` every no_auth request already carries
+   * (`X-Twing-Developer-Id`, attribution only) -- `orgId` null, GitHub
+   * binding best-effort from whichever call founds first (normally
+   * `/v1/constraints/seed` from `twing init`, which carries owner/repo; a
+   * hook gate call that founds first carries none and is never backfilled --
+   * the same one-shot founding limitation the other two paths have).
+   *
+   * Unlike `foundProject`/`foundProjectViaGithub` this is reachable on every
+   * Edit/Write gate call (via `authorizeProject`), not just once at
+   * onboarding, so it uses `onConflictDoNothing()` rather than their plain
+   * check-then-insert -- two agent sessions racing first contact with a new
+   * project must not 500 the second one. Idempotent; the caller still guards
+   * with `isProjectFounded` so the common case does no writes at all.
+   */
+  foundProjectNoAuth(projectId: string, developerId: string, github?: { owner: string; repo: string }): ProjectRecord {
+    this.db
+      .insert(projectRecordsTable)
+      .values({
+        projectId,
+        orgId: null,
+        foundedBy: developerId,
+        foundedAt: Date.now(),
+        githubOwner: github?.owner ?? null,
+        githubRepo: github?.repo ?? null,
+      })
+      .onConflictDoNothing()
+      .run();
+    this.grantProjectMembership(projectId, developerId, "admin");
+    return this.getProjectRecord(projectId)!;
   }
 
   getProjectRole(projectId: string, developerId: string): Role | undefined {


### PR DESCRIPTION
## Problem

On a `twing serve --no-auth` / `TWING_AUTH_MODE=no_auth` coordinator, `twing init` never creates a `ProjectRecord`. Claims, designs, and constraints still function (they key off the bare `projectId` string — no FK, no existence check), but:

- **`GET /v1/projects` is always empty** on a no-auth coordinator (it maps over `identity.projects`, which the no-auth middleware hard-codes to `[]`), so twing-monitor / any dashboard shows zero projects.
- the repo's **GitHub owner/repo binding is silently discarded** — `twing init` sends it in the `/v1/constraints/seed` body but nothing in no-auth mode consumes it.
- `foundedBy` / `foundedAt` are never recorded.
- a non-GitHub repo with an empty `.twing/twing.yml` makes `twing init` a **complete server no-op** — `seedConstraints` early-returns without any HTTP call.

### Root cause

- `authorizeProject()` starts with `if (noAuth) return { ok: true };` — returning *before* the lazy `if (!isProjectFounded) foundProject(...)` branch that registers a project on the authed path.
- `IdentityStore.foundProject()` also requires the founder to already have an `org_memberships` row — impossible in no-auth, where no identity tables are ever populated.
- `foundProjectViaGithub` is unreachable: the CLI's `resolveAuthToken()` returns `undefined` on `auth?.noAuth` before any `runJoinGithub` call, and the route needs a bearer token / client `tokenHash` no-auth never has.

## Changes

- **`IdentityStore.foundProjectNoAuth`** — founds a bare `project_records` row (`orgId` null, GitHub binding best-effort) plus an admin membership, straight from the self-declared `developerId` every no-auth request carries. Uses `onConflictDoNothing()` (rather than `foundProject`'s plain check-then-insert) because it's now reachable on every Edit/Write gate call, not just once at onboarding — two racing sessions must not 500 the second one.
- **`IdentityStore.listAllProjectRecords`** — unscoped, for the no-auth listing only.
- **`authorizeProject()`** — in no-auth, lazily found the project when `!isProjectFounded`, then return `{ ok: true }`. Same lazy-founding breadth every project-scoped route (`/v1/claims`, `/v1/designs/check`, `/v1/constraints/*`, gate paths) already gets in authed mode.
- **`GET /v1/projects`** — in no-auth, list all founded records; the authed branch is byte-for-byte unchanged.
- **`packages/cli/src/init.ts`** — thread the effective (sticky) no-auth flag into `seedConstraints` and keep the registration call firing even with an empty manifest; tidy the zero-constraint log line to `registered this repo with the coordinator`.

## Not changed

- **Go hook** — the gate path only calls `/v1/designs/check` and `/v1/constraints/match` (verdict-only, tolerate a bare `projectId`); it already sends `X-Twing-Developer-Id` in no-auth, so lazy founding attributes `foundedBy` correctly.
- **DB schema / migrations** — `project_records.orgId` is already nullable; `foundProjectViaGithub` already writes `orgId: null` rows.
- **`/v1/constraints/seed` admin gate** — `canManageProject` returns `true` for everyone in no-auth regardless, so re-seed stays allowed (inherent to no-auth mode).

## Tests

- `packages/server/src/app.test.ts` — new no-auth cases: `/v1/constraints/seed` founds a record with the GitHub binding + `foundedBy` from the header; `GET /v1/projects` lists every founded project; re-seed is idempotent (one record, original founder kept); bare `/v1/claims` and `/v1/designs/check` calls also found the project.
- `packages/cli/src/init.test.ts` — `--no-auth` with an empty manifest still calls `/v1/constraints/seed` carrying an `X-Twing-Developer-Id` header; a second plain `twing init` against an already-cached no-auth server still fires it. New `cacheNoAuth` test helper.

`npm run build`, `npm run test` (core 34 / cli 116 / server 414 pass), and `typecheck` for `packages/server` + `packages/cli` all clean. The one failing test in the full run — `simulator/version-gate.test.js` — is pre-existing and environmental (`spawnSync go ENOENT`; no Go toolchain on this machine) and unrelated to this TS-only change.