### PR TITLE
Bump @twing/core, @twing/cli, and @twing/server to 0.2.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2532,10 +2532,10 @@
     },
     "packages/cli": {
       "name": "@twing/cli",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@twing/core": "^0.2.12",
+        "@twing/core": "^0.2.13",
         "web-tree-sitter": "^0.26.12"
       },
       "bin": {
@@ -2544,7 +2544,7 @@
     },
     "packages/core": {
       "name": "@twing/core",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "minimatch": "^10.0.1",
@@ -2556,7 +2556,7 @@
     },
     "packages/server": {
       "name": "@twing/server",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@hono/node-server": "^2.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twing/cli",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "license": "MIT OR Apache-2.0",
   "type": "module",
   "bin": {
@@ -26,7 +26,7 @@
     "test": "node --test dist/*.test.js"
   },
   "dependencies": {
-    "@twing/core": "^0.2.12",
+    "@twing/core": "^0.2.13",
     "web-tree-sitter": "^0.26.12"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twing/core",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "license": "MIT OR Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twing/server",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "license": "AGPL-3.0-only",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump releasing the no-auth project-registration fix (PR #17, merged in eec3fb7).

Before that fix, `twing init` against a `twing serve --no-auth` coordinator never created a `ProjectRecord`: `authorizeProject` short-circuited before the lazy founding branch, so the dashboard's `GET /v1/projects` was always empty and the repo's GitHub owner/repo binding was silently dropped. As of 0.2.13, every project-scoped route lazily founds the project in no-auth mode (same breadth as authed mode), `GET /v1/projects` lists all founded records, and `twing init` sends the registration call even for a repo with an empty `.twing/twing.yml`.

All three package versions bumped 0.2.12 -> 0.2.13 in lockstep (plus `@twing/cli`'s `@twing/core` pin and `package-lock.json`), matching the prior release commit shape (66b1d0e).