### PR TITLE
Surface the semantic comparator's reasoning + a resolution menu on a design-gate deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,29 @@ on a fresh session's very first deny, to check `twing design list --mine
 --status open` first and join an existing open design of yours via `amend
 --group` if one already covers the same effort, rather than registering a
 new one for it. Follow whichever it tells you, then retry the original
-edit. Two things worth knowing before you do:
+edit.
+
+A peer-vs-peer deny (`symbol_conflict` / `llm_divergence`) presents its
+resolutions as a numbered pick-one menu, with the other design's summary
+and -- for `llm_divergence` -- the semantic comparator's own explanation of
+why the two plans clash, including a one-line `Suggested:` resolution when
+the model offered one. The counterpart design's id is filled straight into
+the `--adopt` command, so option `[1]` is copy-paste runnable. **Surface
+that menu (and the suggestion) to the operator rather than picking for
+them** -- the choice between adopting someone else's design, narrowing your
+own, or proceeding separately is theirs to make. The options:
+
+| # | Command | What it does |
+| - | ------- | ------------ |
+| `[1]` | `resolve --id <yours> --adopt <theirs>` | Drop your design, build on theirs (supersedes yours). |
+| `[2]` | `resolve --id <yours> --merge --touches <files>` | Narrow your own scope to just those paths; the server re-checks the narrowed shape and only clears the flag if it comes back clean. |
+| `[3]` | `resolve --id <yours> --justify "<why>"` | Proceed separately -- self-approves immediately for these two buckets (see below). |
+| `[4]` | `twing design close --id <yours>` | That work is done / no longer applies. |
+
+`twing design resolve --id <id>` with no resolution flag opens the same menu
+interactively when run in a terminal.
+
+Two things worth knowing before you resolve:
 
 - **`resolve --justify` unblocks you immediately for a `symbol_conflict` or
   `llm_divergence` deny, but not for `constraint_violation`.** The two

--- a/hook/design_gate.go
+++ b/hook/design_gate.go
@@ -1175,6 +1175,20 @@ type designScopeMatchResponse struct {
 	// outOfScopeReason falls back to a one-candidate list built from
 	// `DesignID` alone.
 	OpenDesigns []designSummary `json:"openDesigns,omitempty"`
+	// Set only for state "flagged" with a peer-vs-peer verdict
+	// ("llm_divergence"/"symbol_conflict") -- the counterpart design this one
+	// collides with, pulled off the shared alignment thread server-side.
+	// ConflictingDesignID is filled into flaggedDesignReason's `--adopt`
+	// command so the menu is copy-paste runnable; ConflictSummary names the
+	// other plan; ConflictReason is the comparator's explanation, already
+	// carrying a "Suggested: ..." line when the model offered one (app.ts's
+	// runSemanticComparatorPass). All three absent (older coordinator, or a
+	// "constraint_violation" flag, which has no counterpart) -> the menu
+	// still renders, just with the generic lead sentence and a
+	// `<theirPlanId>` placeholder.
+	ConflictingDesignID string `json:"conflictingDesignId,omitempty"`
+	ConflictSummary     string `json:"conflictSummary,omitempty"`
+	ConflictReason      string `json:"conflictReason,omitempty"`
 }
 
 // designSummary is the minimal per-design context outOfScopeReason needs to
@@ -1239,10 +1253,11 @@ func checkDesignScope(serverURL, authToken, developerID, projectID, sessionID, f
 // whoever's authority you'd be overriding" principle this reflects. When
 // `pendingReview` is also true, `requiresAdmin` further distinguishes
 // "waiting on a person" from "already resolved, nothing more to do".
-func flaggedDesignReason(designID string, pendingReview bool, requiresAdmin bool, verdict string) string {
-	lead, detail := flaggedLeadAndDetail(verdict)
-	if pendingReview {
-		if requiresAdmin {
+func flaggedDesignReason(m designScopeMatchResponse) string {
+	designID := m.DesignID
+	lead, detail := flaggedLeadAndDetail(m.Verdict)
+	if m.PendingReview {
+		if m.RequiresAdmin {
 			return denyMessage(
 				"You're waiting on a person, not on twing.",
 				"Your explanation has been sent to a project admin. There's nothing more to do "+
@@ -1268,37 +1283,75 @@ func flaggedDesignReason(designID string, pendingReview bool, requiresAdmin bool
 			[]denyAction{{Label: "Retry your edit"}},
 		)
 	}
-	note := "This is self-approvable -- you'll be unblocked as soon as you submit it, no admin needed."
-	if requiresAdmin {
-		note = "This goes to a project admin. You stay blocked until they decide."
+
+	// constraint_violation is one design vs. a fixed project rule -- there's
+	// no counterpart design to adopt and the justification goes to a project
+	// admin, so this bucket keeps its original adjust/justify/close message
+	// rather than the peer-vs-peer pick-one menu below.
+	if m.RequiresAdmin {
+		return denyMessage(
+			lead,
+			detail,
+			[]denyDetail{{"Your plan", designID}, {"Status", "on hold until resolved"}},
+			[]denyAction{
+				{
+					Label:   "Build on their work instead",
+					Command: fmt.Sprintf("twing design resolve --id %s --adopt <theirPlanId>", designID),
+				},
+				{
+					Label:   "Or explain why yours needs to be separate",
+					Command: fmt.Sprintf("twing design resolve --id %s --justify \"<reason>\"", designID),
+					Note:    "This goes to a project admin. You stay blocked until they decide.",
+				},
+				{
+					Label:   "Or, if that work is done and this doesn't apply anymore",
+					Command: fmt.Sprintf("twing design close --id %s", designID),
+				},
+			},
+		)
 	}
+
+	// Peer-vs-peer (llm_divergence / symbol_conflict, or a legacy "" verdict
+	// from a pre-2026 coordinator): a numbered pick-one menu. The "why" is
+	// the comparator's own explanation when the coordinator sent one
+	// (ConflictReason, already carrying a "Suggested: ..." clause when the
+	// model offered a resolution hint -- newlines in it collapse to spaces
+	// through denyMessage's wrapper, which is fine); otherwise the generic
+	// per-bucket sentence. `--adopt` is pre-filled with the counterpart id
+	// when known, so option [1] is copy-paste runnable.
+	why := detail
+	if m.ConflictReason != "" {
+		why = m.ConflictReason
+	}
+	adoptTarget := m.ConflictingDesignID
+	if adoptTarget == "" {
+		adoptTarget = "<theirPlanId>"
+	}
+	details := []denyDetail{{"Your plan", designID}}
+	if m.ConflictSummary != "" {
+		details = append(details, denyDetail{"Their plan", m.ConflictSummary})
+		if m.ConflictingDesignID != "" {
+			details = append(details, denyDetail{"", "design " + m.ConflictingDesignID})
+		}
+	}
+	details = append(details, denyDetail{"Status", "on hold until resolved"})
+
 	return denyMessage(
-		lead,
-		detail,
-		[]denyDetail{{"Your plan", designID}, {"Status", "on hold until resolved"}},
+		"Someone else is already building this. Pick how to resolve it.",
+		why,
+		details,
 		[]denyAction{
 			{
-				Label:   "Build on their work instead",
-				Command: fmt.Sprintf("twing design resolve --id %s --adopt <theirPlanId>", designID),
+				Label:   "[1] Adopt their design -- drop yours and build on theirs",
+				Command: fmt.Sprintf("twing design resolve --id %s --adopt %s", designID, adoptTarget),
 			},
 			{
-				Label:   "Or explain why yours needs to be separate",
-				Command: fmt.Sprintf("twing design resolve --id %s --justify \"<reason>\"", designID),
-				Note:    note,
+				Label:   "[2] Keep yours separate -- if these genuinely don't overlap",
+				Command: fmt.Sprintf("twing design resolve --id %s --justify \"<why they're distinct>\"", designID),
+				Note:    "Self-approvable -- you're unblocked as soon as you submit it, no admin needed.",
 			},
-			// Tightening alignment threads, item 2 (2026-08-27): the deny
-			// message used to only ever offer adopt/justify, with no way to
-			// say "this doesn't apply to me anymore" -- `designs.close()`
-			// (design-store.ts) already accepts a design out of any of
-			// open/flagged/dormant unconditionally, the gate just never told
-			// anyone that was an option. Mirrors the same three-way
-			// join/close/force shape the now-retired `has_open_designs`
-			// verdict's deny message used to use, uniformly across all
-			// three flagging verdicts rather than special-cased per bucket
-			// -- closing is just as valid a response to "someone beat you
-			// to this" as it is to "you've since moved on".
 			{
-				Label:   "Or, if that work is done and this doesn't apply anymore",
+				Label:   "[3] Drop yours -- if that work is done and this no longer applies",
 				Command: fmt.Sprintf("twing design close --id %s", designID),
 			},
 		},
@@ -1656,7 +1709,7 @@ func handleEditWriteGate(payload hookPayload) {
 	case "in_scope":
 		writeJSON(allowOutput("PreToolUse"))
 	case "flagged":
-		writeJSON(denyOutput("PreToolUse", flaggedDesignReason(scopeMatch.DesignID, scopeMatch.PendingReview, scopeMatch.RequiresAdmin, scopeMatch.Verdict)))
+		writeJSON(denyOutput("PreToolUse", flaggedDesignReason(scopeMatch)))
 	case "dormant":
 		writeJSON(denyOutput("PreToolUse", dormantDesignReason(scopeMatch.DesignID, scopeMatch.Summary, scopeMatch.DormantSinceMs)))
 	case "out_of_scope":

--- a/hook/design_gate_test.go
+++ b/hook/design_gate_test.go
@@ -1193,12 +1193,19 @@ func allDenyMessages(t *testing.T) map[string]string {
 	}
 	return map[string]string{
 		"noDesign":              noDesignReason(),
-		"flagged":               flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, true, "constraint_violation"),
-		"flaggedPendingRev":     flaggedDesignReason("11111111-2222-3333-4444-555555555555", true, true, "constraint_violation"),
-		"flaggedSelfApprove":    flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, false, "symbol_conflict"),
-		"flaggedSymbolConflict": flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, false, "symbol_conflict"),
-		"flaggedLlmDivergence":  flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, false, "llm_divergence"),
-		"flaggedLegacyVerdict":  flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, false, ""),
+		"flagged":               flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", RequiresAdmin: true, Verdict: "constraint_violation"}),
+		"flaggedPendingRev":     flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", PendingReview: true, RequiresAdmin: true, Verdict: "constraint_violation"}),
+		"flaggedSelfApprove":    flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", Verdict: "symbol_conflict"}),
+		"flaggedSymbolConflict": flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", Verdict: "symbol_conflict"}),
+		"flaggedLlmDivergence":  flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", Verdict: "llm_divergence"}),
+		"flaggedLlmWithReason": flaggedDesignReason(designScopeMatchResponse{
+			DesignID:            "11111111-2222-3333-4444-555555555555",
+			Verdict:             "llm_divergence",
+			ConflictingDesignID: "66666666-7777-8888-9999-000000000000",
+			ConflictSummary:     "add token-bucket rate limiting as gateway middleware",
+			ConflictReason:      "Both plans build request-throttling for the same service. Suggested: build on the gateway limiter and drop the per-user counter.",
+		}),
+		"flaggedLegacyVerdict": flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", Verdict: ""}),
 		"outOfScope":         outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts", nil),
 		"outOfScopeMulti": outOfScopeReason("11111111-2222-3333-4444-555555555555", "src/net/retry.ts", []designSummary{
 			{ID: "11111111-2222-3333-4444-555555555555", Summary: "add retry with backoff"},
@@ -1294,7 +1301,7 @@ func TestAuthRejectedReason_DistinguishesUnauthorizedFromForbidden(t *testing.T)
 // registration, so the old "conflict from its own registration" wording was
 // simply false in the common case.
 func TestFlaggedDesignReason_DoesNotClaimConflictCameFromRegistration(t *testing.T) {
-	msg := flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, true, "constraint_violation")
+	msg := flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", RequiresAdmin: true, Verdict: "constraint_violation"})
 	if strings.Contains(msg, "registration") {
 		t.Errorf("should not attribute the conflict to registration time: %q", msg)
 	}
@@ -1309,7 +1316,8 @@ func TestFlaggedDesignReason_DoesNotClaimConflictCameFromRegistration(t *testing
 // relevant next step.
 func TestFlaggedDesignReason_OffersCloseAcrossAllThreeVerdicts(t *testing.T) {
 	for _, verdict := range []string{"constraint_violation", "symbol_conflict", "llm_divergence"} {
-		msg := flaggedDesignReason("11111111-2222-3333-4444-555555555555", false, false, verdict)
+		requiresAdmin := verdict == "constraint_violation"
+		msg := flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", RequiresAdmin: requiresAdmin, Verdict: verdict})
 		wantCmd := "twing design close --id 11111111-2222-3333-4444-555555555555"
 		if !strings.Contains(msg, wantCmd) {
 			t.Errorf("%s: expected a close action (%q), got %q", verdict, wantCmd, msg)
@@ -1321,6 +1329,53 @@ func TestFlaggedDesignReason_OffersCloseAcrossAllThreeVerdicts(t *testing.T) {
 		}
 		if !strings.Contains(msg, "twing design resolve --id 11111111-2222-3333-4444-555555555555 --justify") {
 			t.Errorf("%s: justify action must still be present alongside close, got %q", verdict, msg)
+		}
+	}
+}
+
+// Peer-vs-peer flag: when the coordinator sends the counterpart design +
+// the comparator's reason, the deny message must (a) fill the real id into
+// the --adopt command instead of the <theirPlanId> placeholder, (b) show
+// the comparator's own explanation including any "Suggested:" clause, and
+// (c) still list all three resolutions as a numbered pick-one menu.
+func TestFlaggedDesignReason_SurfacesConflictReasonAndFillsAdoptID(t *testing.T) {
+	msg := flaggedDesignReason(designScopeMatchResponse{
+		DesignID:            "11111111-2222-3333-4444-555555555555",
+		Verdict:             "llm_divergence",
+		ConflictingDesignID: "66666666-7777-8888-9999-000000000000",
+		ConflictSummary:     "add token-bucket rate limiting as gateway middleware",
+		ConflictReason:      "Both plans build request-throttling for the same service. Suggested: build on the gateway limiter and drop the per-user counter.",
+	})
+	if !strings.Contains(msg, "--adopt 66666666-7777-8888-9999-000000000000") {
+		t.Errorf("adopt command should be pre-filled with the counterpart id, got %q", msg)
+	}
+	if strings.Contains(msg, "<theirPlanId>") {
+		t.Errorf("placeholder should be gone once the counterpart id is known, got %q", msg)
+	}
+	if !strings.Contains(msg, "request-throttling for the same service") {
+		t.Errorf("should surface the comparator's reason, got %q", msg)
+	}
+	if !strings.Contains(msg, "Suggested:") {
+		t.Errorf("should carry the model's resolution hint, got %q", msg)
+	}
+	for _, want := range []string{"[1]", "[2]", "[3]", "--adopt", "--justify", "twing design close --id"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("pick-one menu missing %q, got %q", want, msg)
+		}
+	}
+}
+
+// Without the optional counterpart fields (older coordinator, or a
+// constraint_violation), the peer menu still renders -- placeholder id,
+// generic per-bucket lead sentence, all three options.
+func TestFlaggedDesignReason_PeerMenuDegradesWithoutConflictFields(t *testing.T) {
+	msg := flaggedDesignReason(designScopeMatchResponse{DesignID: "11111111-2222-3333-4444-555555555555", Verdict: "llm_divergence"})
+	if !strings.Contains(msg, "--adopt <theirPlanId>") {
+		t.Errorf("should fall back to the placeholder when no counterpart id, got %q", msg)
+	}
+	for _, want := range []string{"[1]", "[2]", "[3]"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("menu missing %q, got %q", want, msg)
 		}
 	}
 }

--- a/packages/cli/src/design.test.ts
+++ b/packages/cli/src/design.test.ts
@@ -193,12 +193,33 @@ test("runDesignResolve: --justify sends resolution: justified_divergence", async
   });
 });
 
-test("runDesignResolve: throws without --id, or without --adopt/--justify", async () => {
+test("runDesignResolve: --merge sends resolution: merged with the narrowed scope (replacing, not adding)", async () => {
+  const { fetch, calls } = captureFetch(jsonResponse({ status: "resolved", verdict: "clean" }));
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    await withMockFetch(fetch, () => runDesignResolve({ cwd: repo, id: "d1", merge: true, touches: "src/auth.ts,src/quota.ts", creates: "" }));
+    assert.match(calls[0].url, /\/v1\/designs\/d1\/resolve$/);
+    assert.deepEqual(calls[0].body, { resolution: "merged", mergedTouches: ["src/auth.ts", "src/quota.ts"], mergedCreates: [] });
+  });
+});
+
+test("runDesignResolve: --merge that re-checks non-clean reports still-blocked without changing anything", async () => {
+  const { fetch } = captureFetch(jsonResponse({ status: "flagged", verdict: "constraint_violation" }));
+  await withHome(async () => {
+    cacheToken(SERVER_URL, "test-token");
+    const repo = tmpRepo(SERVER_URL);
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runDesignResolve({ cwd: repo, id: "d1", merge: true, touches: "protected.ts" })));
+    assert.ok(logs.some((l) => /still blocked/.test(l) && /constraint_violation/.test(l)), logs.join("\n"));
+  });
+});
+
+test("runDesignResolve: throws without --id, or without a resolution flag when there's no TTY", async () => {
   await withHome(async () => {
     cacheToken(SERVER_URL, "test-token");
     const repo = tmpRepo(SERVER_URL);
     await assert.rejects(() => runDesignResolve({ cwd: repo, adopt: "d2" }), /--id/);
-    await assert.rejects(() => runDesignResolve({ cwd: repo, id: "d1" }), /--adopt.*--justify/);
+    await assert.rejects(() => runDesignResolve({ cwd: repo, id: "d1" }), /--adopt.*--justify.*--merge/);
   });
 });
 

--- a/packages/cli/src/design.ts
+++ b/packages/cli/src/design.ts
@@ -245,6 +245,57 @@ export interface ResolveOptions {
   id?: string;
   adopt?: string;
   justify?: string;
+  /** `--merge`: narrow this flagged design's own scope to the given
+   * `--touches`/`--creates` (replacing, not adding), dropping the overlap
+   * with the counterpart. The server re-checks the narrowed shape and only
+   * clears the flag if it comes back clean. */
+  merge?: boolean;
+  touches?: string;
+  creates?: string;
+}
+
+/** The four ways out of a peer-vs-peer design flag, in the same order the
+ * Go hook's deny message lists them -- shared so the interactive prompt and
+ * that message can't drift. */
+const RESOLVE_CHOICES = [
+  "Adopt their design  (drop yours, build on theirs)",
+  "Split the work  (narrow your scope so it stops overlapping)",
+  "Keep yours separate  (justify why these don't actually overlap)",
+  "Drop yours  (that work is done / no longer applies)",
+] as const;
+
+async function promptResolution(id: string): Promise<{ resolution: string; [k: string]: unknown } | undefined> {
+  if (!process.stdin.isTTY) {
+    throw new Error('twing design resolve: pass --adopt <designId>, --justify "<reason>", or --merge --touches <files> (no TTY for the interactive picker)');
+  }
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    console.log(`\nResolving design ${id} -- how do you want to resolve this conflict?\n`);
+    RESOLVE_CHOICES.forEach((c, i) => console.log(`  ${i + 1}. ${c}`));
+    const pick = (await rl.question("\nChoose 1-4 (or q to cancel): ")).trim();
+    switch (pick) {
+      case "1": {
+        const other = (await rl.question("Their design id (--adopt): ")).trim();
+        return other ? { resolution: "adopted", adoptedDesignId: other } : undefined;
+      }
+      case "2": {
+        const touches = (await rl.question("Paths that stay on YOUR side, comma-separated (--touches): ")).trim();
+        const creates = (await rl.question("...and any new files you'll still create (--creates, blank for none): ")).trim();
+        return { resolution: "merged", mergedTouches: splitList(touches), mergedCreates: splitList(creates) };
+      }
+      case "3": {
+        const why = (await rl.question("Why are these genuinely separate? ")).trim();
+        return why ? { resolution: "justified_divergence", justification: why } : undefined;
+      }
+      case "4":
+        return { resolution: "__close__" };
+      default:
+        return undefined;
+    }
+  } finally {
+    rl.close();
+  }
 }
 
 export async function runDesignResolve(options: ResolveOptions): Promise<void> {
@@ -253,13 +304,26 @@ export async function runDesignResolve(options: ResolveOptions): Promise<void> {
   if (!options.id) {
     throw new Error("twing design resolve: --id <designId> is required");
   }
-  if (!options.adopt && !options.justify) {
-    throw new Error('twing design resolve: pass --adopt <designId> or --justify "<reason>"');
-  }
 
-  const body = options.adopt
-    ? { resolution: "adopted", adoptedDesignId: options.adopt }
-    : { resolution: "justified_divergence", justification: options.justify };
+  let body: { resolution: string; [k: string]: unknown };
+  if (options.adopt) {
+    body = { resolution: "adopted", adoptedDesignId: options.adopt };
+  } else if (options.merge) {
+    body = { resolution: "merged", mergedTouches: splitList(options.touches), mergedCreates: splitList(options.creates) };
+  } else if (options.justify) {
+    body = { resolution: "justified_divergence", justification: options.justify };
+  } else {
+    const chosen = await promptResolution(options.id);
+    if (!chosen) {
+      console.log("twing design resolve: cancelled, nothing changed.");
+      return;
+    }
+    if (chosen.resolution === "__close__") {
+      await runDesignClose({ cwd: options.cwd, id: options.id });
+      return;
+    }
+    body = chosen;
+  }
 
   const res = await authFetch(
     `${serverUrl}/v1/designs/${options.id}/resolve`,
@@ -271,7 +335,7 @@ export async function runDesignResolve(options: ResolveOptions): Promise<void> {
     authToken,
     developerId,
   );
-  const result = (await parseJsonOrUnauthorized(res)) as { error?: string; status?: string; reviewId?: string };
+  const result = (await parseJsonOrUnauthorized(res)) as { error?: string; status?: string; reviewId?: string; verdict?: string };
   // 2026-08-26 self-approve: `/v1/designs/:id/resolve` now distinguishes
   // "resolved" (no constraint hit in the mix -- decided immediately, the
   // design is unblocked right now) from "pending_review" (a constraint
@@ -280,9 +344,13 @@ export async function runDesignResolve(options: ResolveOptions): Promise<void> {
   // core/types.ts, for the full four-bucket model this line reflects.
   if (!result.error) {
     if (result.status === "resolved") {
-      console.log(`twing design: unblocked -- self-approved, no admin needed (review ${result.reviewId}).`);
+      const via = body.resolution === "merged" ? "narrowed scope re-checked clean" : "self-approved, no admin needed";
+      console.log(`twing design: unblocked -- ${via}${result.reviewId ? ` (review ${result.reviewId})` : ""}.`);
     } else if (result.status === "pending_review") {
       console.log(`twing design: waiting on a project admin -- run \`twing design reviews --decide ${result.reviewId} --decision approve\` (as an admin) to unblock.`);
+    } else if (result.status === "flagged") {
+      // `--merge` only: the narrowed scope still didn't come back clean.
+      console.log(`twing design: still blocked -- the narrowed scope re-checked as "${result.verdict}". Nothing was changed; widen the narrowing or pick another resolution.`);
     }
   }
   console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -96,7 +96,7 @@ function printUsage(): void {
       "  twing project remove-developer --developer-id <id> [--project <id>] [--server <url>]",
       "  twing project list-developers [--project <id>] [--server <url>]",
       "  twing design register --session <id> --summary \"...\" --creates a,b --touches c,d --depends-on e,f [--group <groupId>]",
-      "  twing design resolve --id <designId> (--adopt <designId> | --justify \"...\")",
+      "  twing design resolve --id <designId> (--adopt <designId> | --justify \"...\" | --merge --touches <files>)",
       "  twing design amend --id <designId> [--touches a,b] [--creates c,d] [--depends-on e,f] [--summary \"...\"] [--group <groupId>]",
       "  twing design amend --id <designId> --reassign-project   (run from the correct repo -- moves an open, unencumbered design there)",
       "  twing design resume --id <designId> [--session <id>] [--touches a,b] [--creates c,d] [--depends-on e,f]",
@@ -142,7 +142,15 @@ async function runDesignCommand(rest: string[]): Promise<void> {
       });
       return;
     case "resolve":
-      await runDesignResolve({ cwd, id: flags.id, adopt: flags.adopt, justify: flags.justify });
+      await runDesignResolve({
+        cwd,
+        id: flags.id,
+        adopt: flags.adopt,
+        justify: flags.justify,
+        merge: flags.merge === "true",
+        touches: flags.touches,
+        creates: flags.creates,
+      });
       return;
     case "amend":
       await runDesignAmend({

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1608,6 +1608,113 @@ test("POST /v1/designs/:id/resolve: self-approving an llm_divergence block posts
   assert.equal(resolutionNote!.authorId, undefined, "a system note, not posted as either party");
 });
 
+// LLM-assisted resolution, `resolution: "merged"`: the flagged session
+// narrows its own scope to stop overlapping the counterpart. A narrowed
+// shape that re-checks clean clears the flag (status back to "open",
+// blockedReason cleared, scopeVersion bumped); the shared thread settles if
+// the other side is done too.
+test("POST /v1/designs/:id/resolve: merged narrows the design's scope and clears the flag when the narrowed shape re-checks clean", async () => {
+  const { app, dataDir, designs, alignmentThreads } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir); // alice
+
+  const aliceRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-alice", summary: "alice's limiter", creates: [], touches: ["gateway.ts", "limits.ts"], dependsOn: [] }),
+  });
+  const { designId: aliceId } = (await aliceRes.json()) as { designId: string };
+
+  const otherPat = await addProjectMember(app, admin.token, "proj-1");
+  const bobRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(otherPat) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-bob", summary: "bob's quotas", creates: [], touches: ["auth.ts", "limits.ts"], dependsOn: [] }),
+  });
+  const { designId: bobId } = (await bobRes.json()) as { designId: string };
+
+  const thread = alignmentThreads.findOrCreate({
+    projectId: "proj-1",
+    symbolIds: [],
+    developerId: "bob@example.com",
+    otherDeveloperId: admin.developerId,
+    designId: aliceId,
+    systemDescription: "both touch limits.ts. Suggested: let the gateway own limits config.",
+    category: "llm_divergence",
+    subKind: "duplication",
+    summary: "dup",
+    initiatingDesignId: bobId,
+    ts: Date.now(),
+    reopenEligible: false,
+  });
+  designs.flag(bobId, "llm_divergence", { conflicts: [{ conflictingDesignId: aliceId, overlapKind: "touches", overlapDetail: "limits.ts", conflictingSummary: "alice's limiter", overlapPaths: ["limits.ts"] }] });
+
+  const before = designs.get(bobId)!;
+  const res = await app.request(`/v1/designs/${bobId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(otherPat) },
+    body: JSON.stringify({ resolution: "merged", mergedTouches: ["auth.ts"], mergedCreates: [] }),
+  });
+  const body = (await res.json()) as { status: string; verdict: string };
+  assert.equal(res.status, 200);
+  assert.equal(body.status, "resolved");
+  assert.equal(body.verdict, "clean");
+
+  const after = designs.get(bobId)!;
+  assert.equal(after.status, "open", "flag cleared");
+  assert.equal(after.blockedReason, undefined, "blockedReason cleared (DTO normalizes null -> undefined)");
+  assert.deepEqual(after.touches, ["auth.ts"], "scope replaced, not unioned -- limits.ts is gone");
+  assert.equal(after.scopeVersion, before.scopeVersion + 1);
+  void thread;
+});
+
+test("POST /v1/designs/:id/resolve: merged leaves the design flagged and returns the new verdict when the narrowed scope still violates a constraint", async () => {
+  const { app, dataDir, designs } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected", scope: ["protected.ts"], type: "constraint" }] }),
+  });
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "x", creates: [], touches: ["protected.ts", "safe.ts"], dependsOn: [] }),
+  });
+  const { designId } = (await checkRes.json()) as { designId: string };
+  assert.equal(designs.get(designId)!.status, "flagged");
+
+  // Narrowing still keeps protected.ts -- must not clear.
+  const res = await app.request(`/v1/designs/${designId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ resolution: "merged", mergedTouches: ["protected.ts"], mergedCreates: [] }),
+  });
+  const body = (await res.json()) as { status: string; verdict: string };
+  assert.equal(body.status, "flagged");
+  assert.equal(body.verdict, "constraint_violation");
+  assert.equal(designs.get(designId)!.status, "flagged", "nothing persisted on a non-clean re-check");
+});
+
+test("POST /v1/designs/:id/resolve: merged on a design that isn't flagged is a 409", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  const checkRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "x", creates: [], touches: ["a.ts"], dependsOn: [] }),
+  });
+  const { designId } = (await checkRes.json()) as { designId: string };
+
+  const res = await app.request(`/v1/designs/${designId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ resolution: "merged", mergedTouches: ["a.ts"] }),
+  });
+  assert.equal(res.status, 409);
+});
+
 // The reverse-direction merge (just above) means both sides' resolutions
 // now land in the *same* thread -- this is what actually answers "who
 // unblocked themselves and who didn't" from one place, rather than two
@@ -3587,6 +3694,87 @@ test("GET /v1/designs/scope-match: with more than one flagged design, the one wh
   assert.equal(body.state, "flagged");
   assert.equal(body.designId, olderId, "must name the flagged design whose scope actually covers path, not just the newest");
   assert.notEqual(body.designId, newerId);
+});
+
+// LLM-assisted resolution: for a peer-vs-peer flag, scope-match's flagged
+// branch enriches its response from the shared alignment thread -- the
+// counterpart design id (so the Go hook can pre-fill `--adopt`), that
+// design's summary, and the comparator's reason text (which already carries
+// a "Suggested:" clause when the model offered one).
+test("GET /v1/designs/scope-match: a peer-vs-peer flagged design returns the counterpart id, summary, and comparator reason from its alignment thread", async () => {
+  const { app, dataDir, designs, alignmentThreads } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir); // alice
+
+  const aliceRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-alice", summary: "per-user request quotas in auth middleware", creates: [], touches: ["auth.ts"], dependsOn: [] }),
+  });
+  const { designId: aliceDesignId } = (await aliceRes.json()) as { designId: string };
+
+  const otherPat = await addProjectMember(app, admin.token, "proj-1");
+  const bobRes = await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(otherPat) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s-bob", summary: "token-bucket rate limiting as gateway middleware", creates: [], touches: ["gateway.ts"], dependsOn: [] }),
+  });
+  const { designId: bobDesignId } = (await bobRes.json()) as { designId: string };
+
+  alignmentThreads.findOrCreate({
+    projectId: "proj-1",
+    symbolIds: [],
+    developerId: "bob@example.com",
+    otherDeveloperId: admin.developerId,
+    designId: aliceDesignId,
+    systemDescription: "Both plans build request-throttling for the same service.\n\nSuggested: build on the gateway limiter and drop the per-user counter.",
+    category: "llm_divergence",
+    subKind: "duplication",
+    summary: "duplicate work",
+    initiatingDesignId: bobDesignId,
+    ts: Date.now(),
+    reopenEligible: false,
+  });
+  designs.flag(bobDesignId, "llm_divergence", { conflicts: [{ conflictingDesignId: aliceDesignId, overlapKind: "touches", overlapDetail: "dup", conflictingSummary: "alice's work", overlapPaths: [] }] });
+
+  const scopeMatch = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s-bob&path=gateway.ts`, { headers: bearer(otherPat) });
+  const body = (await scopeMatch.json()) as {
+    state: string;
+    verdict?: string;
+    conflictingDesignId?: string;
+    conflictSummary?: string;
+    conflictReason?: string;
+  };
+  assert.equal(body.state, "flagged");
+  assert.equal(body.verdict, "llm_divergence");
+  assert.equal(body.conflictingDesignId, aliceDesignId);
+  assert.equal(body.conflictSummary, "per-user request quotas in auth middleware");
+  assert.match(body.conflictReason ?? "", /request-throttling for the same service/);
+  assert.match(body.conflictReason ?? "", /Suggested:/);
+});
+
+// A constraint_violation flag has no counterpart design -- scope-match must
+// not attach conflict* fields to it.
+test("GET /v1/designs/scope-match: a constraint_violation flag carries no conflict* enrichment", async () => {
+  const { app, dataDir } = freshApp();
+  const admin = await bootstrapAdmin(app, dataDir);
+
+  await app.request("/v1/constraints/seed", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", constraints: [{ statement: "protected", scope: ["protected.ts"], type: "constraint" }] }),
+  });
+  await app.request("/v1/designs/check", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...bearer(admin.token) },
+    body: JSON.stringify({ projectId: "proj-1", sessionId: "s1", summary: "x", creates: [], touches: ["protected.ts"], dependsOn: [] }),
+  });
+
+  const scopeMatch = await app.request(`/v1/designs/scope-match?projectId=proj-1&sessionId=s1&path=protected.ts`, { headers: bearer(admin.token) });
+  const body = (await scopeMatch.json()) as { state: string; verdict?: string; conflictingDesignId?: string; conflictReason?: string };
+  assert.equal(body.state, "flagged");
+  assert.equal(body.verdict, "constraint_violation");
+  assert.equal(body.conflictingDesignId, undefined);
+  assert.equal(body.conflictReason, undefined);
 });
 
 // Same bug class as the out_of_scope newest-first fix above, applied to the

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -70,9 +70,18 @@ interface DesignCheckRequestBody {
 }
 
 interface ResolveRequestBody {
-  resolution?: "adopted" | "justified_divergence";
+  resolution?: "adopted" | "justified_divergence" | "merged";
   adoptedDesignId?: string;
   justification?: string;
+  /** `resolution: "merged"` only -- the narrowed scope this design keeps
+   * for itself, dropping the overlap with the counterpart. Replaces
+   * `touches`/`creates` outright (not a union like `amend`): merging is
+   * how a session *shrinks* its declared scope to stop colliding. Empty /
+   * omitted arrays are allowed (narrowing a whole side away). The flag
+   * only clears if the narrowed shape re-checks clean; otherwise the new
+   * verdict comes back and nothing is persisted. */
+  mergedTouches?: string[];
+  mergedCreates?: string[];
 }
 
 // §17 scope enforcement (2026-08): "add" fields only -- amend expands an
@@ -660,13 +669,21 @@ export function createApp(options: CreateAppOptions = {}) {
         const liveCurrent = designs.get(current.id);
         const liveOther = designs.get(other.id);
         const reopenEligible = isDesignLive(liveCurrent) || isDesignLive(liveOther);
+        // The comparator's one-line resolution hint (`suggestion`, may be
+        // empty) rides along in the same free text as `reason` -- the
+        // alignment thread has no structured field for it and `scope-match`'s
+        // deny path reads `systemDescription` verbatim (see the flagged
+        // branch below). Kept as a "Suggested:" sentence rather than a
+        // separate column: it never decides anything, the deny menu still
+        // lists every option regardless.
+        const conflictText = result.suggestion ? `${result.reason}\n\nSuggested: ${result.suggestion}` : result.reason;
         const thread = alignmentThreads.findOrCreate({
           projectId: current.projectId,
           symbolIds: [], // no real symbol for a design-vs-design finding
           developerId: current.developerId,
           otherDeveloperId: other.developerId,
           designId: other.id,
-          systemDescription: result.reason,
+          systemDescription: conflictText,
           category: "llm_divergence",
           subKind,
           summary: buildAlignmentSummary(subKind, other.summary, 0),
@@ -680,10 +697,10 @@ export function createApp(options: CreateAppOptions = {}) {
           kind: "design_semantic_conflict",
           relatedId: thread.id,
           ts: Date.now(),
-          payload: { otherDesignId: other.id, kind: result.kind, reason: result.reason },
+          payload: { otherDesignId: other.id, kind: result.kind, reason: result.reason, suggestion: result.suggestion || undefined },
         });
-        store.addNotice(current.developerId, result.reason, Date.now(), thread.id);
-        store.addNotice(other.developerId, result.reason, Date.now(), thread.id);
+        store.addNotice(current.developerId, conflictText, Date.now(), thread.id);
+        store.addNotice(other.developerId, conflictText, Date.now(), thread.id);
         designs.flag(current.id, "llm_divergence", {
           conflicts: [
             {
@@ -1391,13 +1408,50 @@ export function createApp(options: CreateAppOptions = {}) {
     }
 
     const body = await c.req.json<ResolveRequestBody>().catch(() => null);
-    if (!body || (body.resolution !== "adopted" && body.resolution !== "justified_divergence")) {
-      return c.json({ error: "expected resolution: adopted | justified_divergence" }, 400);
+    if (!body || (body.resolution !== "adopted" && body.resolution !== "justified_divergence" && body.resolution !== "merged")) {
+      return c.json({ error: "expected resolution: adopted | justified_divergence | merged" }, 400);
     }
 
     if (body.resolution === "adopted") {
       designs.supersede(id);
       return c.json({ status: "superseded", adoptedDesignId: body.adoptedDesignId });
+    }
+
+    // "merged" -- the session narrows its own declared scope to stop
+    // overlapping the counterpart. Re-runs the syntactic checks
+    // (design-checks.ts tiers 1-3) against the *narrowed* shape, exactly
+    // like `amend` does against its widened one: only if that comes back
+    // clean does the flag clear. The semantic re-check is deliberately left
+    // to the fire-and-forget `runSemanticComparatorPass` kicked below
+    // (never a second synchronous LLM call in this route -- same reasoning
+    // as the `conflictWaivers` read-back note further down) -- so a narrowed
+    // scope that still semantically diverges just re-flags moments later,
+    // same as it would after any amend.
+    if (body.resolution === "merged") {
+      if (design.status !== "flagged") {
+        return c.json({ error: "only a flagged design can be merge-resolved" }, 409);
+      }
+      const narrowed: DesignStatement = {
+        ...design,
+        touches: [...new Set(body.mergedTouches ?? [])],
+        creates: [...new Set(body.mergedCreates ?? [])],
+      };
+      const openOthers = designs.openDesigns(design.projectId, Date.now(), id);
+      const outcome = runDesignChecks(narrowed, openOthers, constraintStore.forProject(design.projectId));
+      if (outcome.verdict !== "clean") {
+        return c.json({ status: "flagged", verdict: outcome.verdict, conflicts: outcome.conflicts, constraints: outcome.constraints });
+      }
+      const merged = designs.mergeResolve(id, { touches: narrowed.touches, creates: narrowed.creates });
+      if (!merged) return c.json({ error: "only a flagged design can be merge-resolved" }, 409);
+      // The overlap is gone as far as the syntactic tiers can tell -- let
+      // any shared thread settle if the other side is done too, then run a
+      // fresh semantic pass that will re-flag if the narrowed scope still
+      // diverges.
+      for (const t of alignmentThreads.listByProject(design.projectId, "open")) {
+        if (t.initiatingDesignId === id || t.designId === id) maybeAutoCloseThread(t.id);
+      }
+      runSemanticComparatorPass(id, designs.openDesigns(design.projectId, Date.now(), id));
+      return c.json({ status: "resolved", verdict: "clean" });
     }
 
     if (!body.justification) {
@@ -1962,12 +2016,44 @@ export function createApp(options: CreateAppOptions = {}) {
       // DesignVerdict's doc comment (core/types.ts) for the full four-bucket
       // model.
       const requiresAdmin = flaggedDesign.blockedReason === "constraint_violation";
+      // For a peer-vs-peer flag (`llm_divergence`/`symbol_conflict`), pull
+      // the counterpart design + the comparator's reason/suggestion text
+      // off the open alignment thread this design is a party to, so the Go
+      // hook's deny message can name the other plan, fill its id into the
+      // `--adopt` command, and show the "Suggested:" line -- instead of the
+      // generic one-sentence wording it falls back to when these are
+      // absent. Same both-sides thread-membership match the `/resolve`
+      // route uses (`initiatingDesignId` *or* `designId`). `constraint_violation`
+      // has no counterpart design, so it's left untouched.
+      let conflictingDesignId: string | undefined;
+      let conflictSummary: string | undefined;
+      let conflictReason: string | undefined;
+      if (flaggedDesign.blockedReason === "llm_divergence" || flaggedDesign.blockedReason === "symbol_conflict") {
+        const thread = alignmentThreads
+          .listByProject(flaggedDesign.projectId, "open")
+          .find(
+            (t) =>
+              (t.category === "llm_divergence" || t.category === "symbol_conflict") &&
+              (t.initiatingDesignId === flaggedDesign.id || t.designId === flaggedDesign.id),
+          );
+        if (thread) {
+          conflictReason = thread.systemDescription;
+          const otherId = thread.initiatingDesignId === flaggedDesign.id ? thread.designId : thread.initiatingDesignId;
+          if (otherId) {
+            conflictingDesignId = otherId;
+            conflictSummary = designs.get(otherId)?.summary;
+          }
+        }
+      }
       return c.json({
         state: "flagged",
         designId: flaggedDesign.id,
         pendingReview: designs.hasPendingReview(flaggedDesign.id),
         requiresAdmin,
         verdict: flaggedDesign.blockedReason,
+        ...(conflictingDesignId ? { conflictingDesignId } : {}),
+        ...(conflictSummary ? { conflictSummary } : {}),
+        ...(conflictReason ? { conflictReason } : {}),
       });
     }
 

--- a/packages/server/src/design-semantic-check.test.ts
+++ b/packages/server/src/design-semantic-check.test.ts
@@ -69,13 +69,13 @@ test("checkSemanticConflict: conflict:true parses kind/reason, sends system+few-
     withMockFetch(
       (async (_url: string, init?: RequestInit) => {
         capturedMessages = JSON.parse(init!.body as string).messages;
-        return llmResponse({ conflict: true, kind: "tension", reason: "they fight over the same guarantee" });
+        return llmResponse({ conflict: true, kind: "tension", reason: "they fight over the same guarantee", suggestion: "pick one owner for the guarantee" });
       }) as typeof fetch,
       () => checkSemanticConflict(candidate, other, { model: "google.gemma-4-31b" }),
     ),
   );
 
-  assert.deepEqual(result, { conflict: true, kind: "tension", reason: "they fight over the same guarantee" });
+  assert.deepEqual(result, { conflict: true, kind: "tension", reason: "they fight over the same guarantee", suggestion: "pick one owner for the guarantee" });
   assert.equal(capturedMessages[0].role, "system");
   // 3 few-shot pairs (6 messages) + the real user turn
   assert.equal(capturedMessages.length, 1 + 6 + 1);
@@ -88,21 +88,41 @@ test("checkSemanticConflict: conflict:true parses kind/reason, sends system+few-
 test("checkSemanticConflict: conflict:false parses cleanly", async () => {
   const result = await withBedrockEnv(() =>
     withMockFetch(
-      (async () => llmResponse({ conflict: false, kind: null, reason: "unrelated" })) as typeof fetch,
+      (async () => llmResponse({ conflict: false, kind: null, reason: "unrelated", suggestion: "" })) as typeof fetch,
       () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
     ),
   );
-  assert.deepEqual(result, { conflict: false, kind: null, reason: "unrelated" });
+  assert.deepEqual(result, { conflict: false, kind: null, reason: "unrelated", suggestion: "" });
+});
+
+test("checkSemanticConflict: a missing suggestion field is tolerated and normalized to empty string", async () => {
+  const result = await withBedrockEnv(() =>
+    withMockFetch(
+      (async () => llmResponse({ conflict: true, kind: "duplication", reason: "same thing twice" })) as typeof fetch,
+      () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
+    ),
+  );
+  assert.deepEqual(result, { conflict: true, kind: "duplication", reason: "same thing twice", suggestion: "" });
+});
+
+test("checkSemanticConflict: a non-string suggestion is coerced to empty string, conflict still stands", async () => {
+  const result = await withBedrockEnv(() =>
+    withMockFetch(
+      (async () => llmResponse({ conflict: true, kind: "duplication", reason: "r", suggestion: { bogus: 1 } })) as typeof fetch,
+      () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
+    ),
+  );
+  assert.deepEqual(result, { conflict: true, kind: "duplication", reason: "r", suggestion: "" });
 });
 
 test("checkSemanticConflict: markdown-fenced JSON is unwrapped", async () => {
   const result = await withBedrockEnv(() =>
     withMockFetch(
-      (async () => llmResponse("```json\n" + JSON.stringify({ conflict: true, kind: "duplication", reason: "r" }) + "\n```")) as typeof fetch,
+      (async () => llmResponse("```json\n" + JSON.stringify({ conflict: true, kind: "duplication", reason: "r", suggestion: "s" }) + "\n```")) as typeof fetch,
       () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
     ),
   );
-  assert.deepEqual(result, { conflict: true, kind: "duplication", reason: "r" });
+  assert.deepEqual(result, { conflict: true, kind: "duplication", reason: "r", suggestion: "s" });
 });
 
 test("checkSemanticConflict: malformed JSON after one retry fails soft to no-conflict", async () => {
@@ -116,7 +136,7 @@ test("checkSemanticConflict: malformed JSON after one retry fails soft to no-con
       () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
     ),
   );
-  assert.deepEqual(result, { conflict: false, kind: null, reason: "" });
+  assert.deepEqual(result, { conflict: false, kind: null, reason: "", suggestion: "" });
   assert.equal(calls, 2);
 });
 
@@ -127,7 +147,7 @@ test("checkSemanticConflict: an invalid kind value is rejected as malformed (fai
       () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
     ),
   );
-  assert.deepEqual(result, { conflict: false, kind: null, reason: "" });
+  assert.deepEqual(result, { conflict: false, kind: null, reason: "", suggestion: "" });
 });
 
 test("checkSemanticConflict: repeated network error fails soft to no-conflict, never throws", async () => {
@@ -139,7 +159,7 @@ test("checkSemanticConflict: repeated network error fails soft to no-conflict, n
       () => checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b" }),
     ),
   );
-  assert.deepEqual(result, { conflict: false, kind: null, reason: "" });
+  assert.deepEqual(result, { conflict: false, kind: null, reason: "", suggestion: "" });
 });
 
 test("checkSemanticConflict: no AWS_BEARER_TOKEN_BEDROCK fails soft to no-conflict, never throws", async () => {
@@ -147,7 +167,7 @@ test("checkSemanticConflict: no AWS_BEARER_TOKEN_BEDROCK fails soft to no-confli
   delete process.env.AWS_BEARER_TOKEN_BEDROCK;
   try {
     const result = await checkSemanticConflict(design({ id: "a" }), design({ id: "b" }), { model: "google.gemma-4-31b", region: "us-east-1" });
-    assert.deepEqual(result, { conflict: false, kind: null, reason: "" });
+    assert.deepEqual(result, { conflict: false, kind: null, reason: "", suggestion: "" });
   } finally {
     if (originalToken === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
     else process.env.AWS_BEARER_TOKEN_BEDROCK = originalToken;

--- a/packages/server/src/design-semantic-check.ts
+++ b/packages/server/src/design-semantic-check.ts
@@ -49,6 +49,18 @@ export interface SemanticConflictResult {
   conflict: boolean;
   kind: SemanticConflictKind | null;
   reason: string;
+  /** One-line, human-readable recommendation for how to resolve the
+   * conflict -- surfaced verbatim in the Edit/Write gate's deny message
+   * (via the alignment thread's `systemDescription`, app.ts's
+   * `runSemanticComparatorPass`) alongside the pick-one adopt/justify/close
+   * menu. Advisory only: it never decides anything, and the menu still
+   * lists every option regardless of what this says. Empty string when
+   * `conflict` is false, or when the model omitted it -- `parseResult`
+   * tolerates its absence (older responses, a malformed field) rather than
+   * dropping an otherwise-valid conflict signal over it. Phrased about the
+   * two *plans/approaches*, not "yours"/"theirs": both sides of a divergent
+   * pair are flagged and read the identical text. */
+  suggestion: string;
 }
 
 export interface SemanticCheckOptions {
@@ -58,7 +70,7 @@ export interface SemanticCheckOptions {
   region?: string;
 }
 
-const EMPTY_RESULT: SemanticConflictResult = { conflict: false, kind: null, reason: "" };
+const EMPTY_RESULT: SemanticConflictResult = { conflict: false, kind: null, reason: "", suggestion: "" };
 
 const SYSTEM_PROMPT = [
   "You are comparing two independent implementation plans for the same codebase, written by different developers who have not seen each other's plan.",
@@ -72,8 +84,9 @@ const SYSTEM_PROMPT = [
   "",
   "Plans can duplicate work or conflict even when they touch completely different files, components, or layers of the system. Do not treat different file paths, or 'different layer/component' framing, as evidence of no conflict by itself -- judge (a)/(b)/(c) on what each plan actually does, not on whether their file lists overlap.",
   "",
-  'Return JSON only: {"conflict": boolean, "kind": "duplication"|"contradictory_assumptions"|"tension"|null, "reason": string}.',
+  'Return JSON only: {"conflict": boolean, "kind": "duplication"|"contradictory_assumptions"|"tension"|null, "reason": string, "suggestion": string}.',
   "reason is required in all cases (even conflict: false) -- one or two sentences, concrete, naming the specific detail from each plan that drove your answer.",
+  'suggestion: when conflict is true, one sentence recommending how to resolve it -- e.g. which approach to build on and which to drop, or how to split the two so they stop overlapping. Refer to the two plans by what they do ("the gateway limiter", "the per-user quota"), never as "Plan A"/"Plan B" or "yours"/"theirs". Empty string "" when conflict is false.',
   "No prose outside the JSON, no markdown code fences.",
 ].join("\n");
 
@@ -100,6 +113,8 @@ const FEW_SHOT: { user: string; assistant: string }[] = [
       kind: "duplication",
       reason:
         "Both plans independently build the same thing -- a per-request LRU read-through cache wrapper around a service method -- in different files. They're the same underlying problem (repeated lookups within a request) solved twice with two divergent implementations instead of one shared utility, even though the files and services are unrelated.",
+      suggestion:
+        "Build one shared per-request read-through cache helper and have both the profile lookup and the order-history lookup call it, instead of landing two separate cache implementations.",
     }),
   },
   {
@@ -119,6 +134,8 @@ const FEW_SHOT: { user: string; assistant: string }[] = [
       kind: "tension",
       reason:
         "Plan A's idle-timeout enforcement lives in the session-refresh middleware and isn't described as aware of Plan B's long_lived flag, while Plan B's skip is described as bypassing 'the normal session-expiry check' without naming the idle-timeout path specifically -- if idle-timeout isn't part of what Plan B's skip covers, a remembered session could get silently logged out despite the 30-day promise; if it is, Plan A's security control gets silently bypassed for those sessions. Either reading is a real tension between the two mechanisms, not a stated agreement about which wins.",
+      suggestion:
+        "Decide together whether the idle-timeout applies to long_lived sessions, then make the idle-timeout check explicitly handle the long_lived flag one way or the other rather than leaving the interaction undefined.",
     }),
   },
   {
@@ -138,6 +155,7 @@ const FEW_SHOT: { user: string; assistant: string }[] = [
       kind: null,
       reason:
         "Both are small, independent UI additions with no shared data, no shared contract, and no overlapping problem -- a Storybook-only dev preview tool and a runtime keyboard-shortcuts modal don't build the same thing, assume anything about each other, or change any behavior the other depends on.",
+      suggestion: "",
     }),
   },
 ];
@@ -172,7 +190,11 @@ function userTurn(candidateText: string, otherText: string): string {
   return `PLAN A:\n${candidateText}\n\n---\n\nPLAN B:\n${otherText}`;
 }
 
-function isValidResult(v: unknown): v is SemanticConflictResult {
+/** `suggestion` is deliberately *not* checked here -- it's advisory-only
+ * (see `SemanticConflictResult.suggestion`), so a missing or non-string
+ * value must never invalidate an otherwise-good conflict judgment.
+ * `parseResult` normalizes it to `""` after this guard passes. */
+function isValidResult(v: unknown): v is Omit<SemanticConflictResult, "suggestion"> {
   if (typeof v !== "object" || v === null) return false;
   const obj = v as Record<string, unknown>;
   if (typeof obj.conflict !== "boolean") return false;
@@ -192,7 +214,9 @@ function parseResult(text: string): SemanticConflictResult | undefined {
   } catch {
     return undefined;
   }
-  return isValidResult(parsed) ? parsed : undefined;
+  if (!isValidResult(parsed)) return undefined;
+  const suggestionRaw = (parsed as Record<string, unknown>).suggestion;
+  return { ...parsed, suggestion: typeof suggestionRaw === "string" ? suggestionRaw.trim() : "" };
 }
 
 function buildMessages(candidate: DesignStatement, other: DesignStatement): ChatMessage[] {

--- a/packages/server/src/design-store.test.ts
+++ b/packages/server/src/design-store.test.ts
@@ -209,6 +209,29 @@ test("DesignRegistry: blockedReason clears on an approved resolve (back to open)
   registry.stop();
 });
 
+test("DesignRegistry: mergeResolve replaces scope, clears the flag, bumps scopeVersion, and only works on a flagged design", () => {
+  const db = createDb({ memory: true });
+  const log = new DrizzleActivityLog(db);
+  const registry = new DesignRegistry(db);
+  const d = registry.register({ projectId: "p1", developerId: "d1", sessionId: "s1", summary: "quotas", creates: ["new.ts"], touches: ["a.ts", "shared.ts"], dependsOn: [] });
+
+  assert.equal(registry.mergeResolve(d.id, { touches: ["a.ts"], creates: [] }), undefined, "an open (not flagged) design has nothing to merge-resolve");
+
+  registry.flag(d.id, "llm_divergence");
+  const before = registry.get(d.id)!;
+  const merged = registry.mergeResolve(d.id, { touches: ["a.ts"], creates: [] });
+  assert.equal(merged?.status, "open");
+  assert.equal(merged?.blockedReason, undefined);
+  assert.deepEqual(merged?.touches, ["a.ts"], "replaced, not unioned -- shared.ts is dropped");
+  assert.deepEqual(merged?.creates, []);
+  assert.equal(merged?.scopeVersion, before.scopeVersion + 1);
+
+  const events = log.eventsForRelatedId(d.id).filter((e) => e.kind === "design_resolved");
+  assert.equal(events.length, 1);
+  assert.equal((events[0].payload as { resolution: string }).resolution, "merged");
+  registry.stop();
+});
+
 test("DesignRegistry: resume clears a stale blockedReason left over from before the design went dormant", () => {
   const db = createDb({ memory: true });
   const registry = new DesignRegistry(db);

--- a/packages/server/src/design-store.ts
+++ b/packages/server/src/design-store.ts
@@ -479,6 +479,49 @@ export class DesignRegistry {
     return this.get(id);
   }
 
+  /** LLM-assisted resolution, `resolution: "merged"` (app.ts's
+   * `/v1/designs/:id/resolve`): a *flagged* design narrows its declared
+   * scope to stop overlapping the counterpart, and -- since the caller has
+   * already re-run `runDesignChecks` against this exact narrowed shape and
+   * got `clean` back -- the flag clears in the same step. Unlike `amend()`
+   * this *replaces* `touches`/`creates` outright rather than unioning
+   * (merging is a deliberate shrink; empty arrays are allowed), only
+   * accepts a `"flagged"` design (an `"open"` one has nothing to
+   * resolve; `amend` is its widen path), and bumps `scopeVersion` so any
+   * in-flight semantic-comparator pass sees it's been superseded.
+   * `blockedReason` clears alongside `status`, same pairing `flag()` sets
+   * them and `decideReview`'s approve path clears them. Returns `undefined`
+   * if the design isn't currently `"flagged"`. */
+  mergeResolve(id: string, scope: { touches: string[]; creates: string[] }): DesignStatement | undefined {
+    const existing = this.get(id);
+    if (!existing || existing.status !== "flagged") return undefined;
+    const touches = [...new Set(scope.touches)];
+    const creates = [...new Set(scope.creates)];
+    const scopeVersion = existing.scopeVersion + 1;
+    this.db
+      .update(designsTable)
+      .set({
+        touches: JSON.stringify(touches),
+        creates: JSON.stringify(creates),
+        status: "open",
+        blockedReason: null,
+        scopeVersion,
+        lastActivityAt: Date.now(),
+      })
+      .where(eq(designsTable.id, id))
+      .run();
+    this.activityLog.append({
+      projectId: existing.projectId,
+      developerId: existing.developerId,
+      sessionId: existing.sessionId,
+      kind: "design_resolved", // same kind supersede() uses; `resolution` distinguishes
+      relatedId: id,
+      ts: Date.now(),
+      payload: { resolution: "merged", touches, creates, priorVerdict: existing.blockedReason ?? undefined },
+    });
+    return this.get(id);
+  }
+
   /** §17 design linking follow-up (2026-08-28): `groupId` was otherwise
    * only ever settable at `register()` time or via `amend()` while a
    * design is `"open"` -- once a design reaches its far more common


### PR DESCRIPTION
## What & why

When an `Edit`/`Write` is blocked by an `llm_divergence` (or `symbol_conflict`) flag, the deny message today shows a generic sentence, three equally-weighted options, and `--adopt <theirPlanId>` as a literal placeholder. The semantic comparator's actual analysis lives only in `twing align threads`.

This PR moves that analysis to the decision point and turns the resolutions into a **pick-one menu**:

- the comparator's own explanation of *why* the two plans clash, plus a one-line `Suggested:` resolution when the model offers one;
- the counterpart design's summary and id, with the id **filled straight into the `--adopt` command**;
- a new `resolve --merge` so "narrow my own scope" is an executable resolution, not just advice.

The LLM's opinion is expressed as text the operator reads; the menu still lists every option and the human/agent picks. No option is auto-selected.

## Changes

| Area | Change |
| --- | --- |
| `design-semantic-check.ts` | `SemanticConflictResult` gains an advisory `suggestion` string; prompt + few-shot updated; `parseResult` tolerates a missing/non-string value (→ `""`). Fail-soft contract unchanged. |
| `app.ts` — `runSemanticComparatorPass` | Folds `suggestion` into the alignment thread's `systemDescription` as a `Suggested:` clause. No new column. |
| `app.ts` — `/v1/designs/scope-match` | Flagged branch returns `conflictingDesignId` / `conflictSummary` / `conflictReason` for peer-vs-peer verdicts, read off the shared thread. `constraint_violation` untouched. |
| `hook/design_gate.go` | `flaggedDesignReason` takes the whole `designScopeMatchResponse`, renders the `[1] adopt / [2] keep separate / [3] close` menu under the comparator's reason. Degrades to the prior wording + `<theirPlanId>` placeholder when the fields are absent (older coordinator). `constraint_violation` keeps its admin-gated message. |
| `resolve --merge` | New `merged` resolution: narrows a flagged design's own scope (replace, not union), re-runs `runDesignChecks`, clears the flag only if the narrowed shape re-checks clean (kicks a fresh semantic pass; still-diverging re-flags). `DesignRegistry.mergeResolve` guards to flagged-only, bumps `scopeVersion`, logs `design_resolved` with `resolution: "merged"`. |
| CLI | `resolve --merge --touches/--creates`; interactive numbered picker when `resolve --id <id>` is run bare in a TTY. |
| README | "For agents: handling a design-gate deny" documents the menu and "surface it, don't pick for them". |

All response fields and the `merged` resolution are additive/optional — an older hook against a newer server (or vice versa) degrades to today's message.

## Compatibility

- `hook/design_gate.go`, `packages/server/src/{app,design-*}.ts` are `require_human_review` in this repo's own `.twing/twing.yml`; the dogfood design review was approved during development.
- No DB migration. Reuses `design_resolved` activity kind (disambiguated by `payload.resolution`).

## Testing

- `npm test`: core 118, cli 34, server+cli 422, simulator 2 — all green.
- `go build ./...` / `go vet ./...` / `go test ./hook/...` — green, including 2 new + 3 updated deny-message tests.
- New coverage: `suggestion` parse tolerance; scope-match peer enrichment (+ constraint_violation carries none); `merged` clean / non-clean / non-flagged (409); `DesignRegistry.mergeResolve` unit; CLI `--merge` request shaping.
