### PR TITLE
Say where captured conversation actually goes

### DIFF
--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -473,6 +473,44 @@ function writeManifest(repo: string, yaml: string): void {
   fs.writeFileSync(path.join(repo, ".twing", "twing.yml"), yaml);
 }
 
+// The capture-ON line is the one sentence someone reads while deciding to
+// let their conversation be recorded, so it has to describe where the
+// conversation actually goes. It said "on this machine, and nowhere else"
+// for a release after the daemon started uploading to the coordinator --
+// accurate for phase 1, wrong from the upload onward, and nothing failed
+// when it drifted. These two assertions are what makes the next such drift
+// fail loudly instead of silently understating the destination.
+test("runInit: the capture-ON line names the coordinator it uploads to, not just the local path", async () => {
+  const { fetch } = bodyCapturingFetch();
+  const { deps } = fakeDeps();
+  await withHome(async () => {
+    const repo = tmpRepo();
+    writeManifest(repo, `coordinator:\n  serverUrl: ${SERVER_URL}\ncapture:\n  enabled: true\n`);
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runInit({ cwd: repo, server: SERVER_URL, noAuth: true }, deps)));
+
+    const line = logs.find((l) => l.includes("session capture ON"));
+    assert.ok(line, `expected a capture-ON line, got: ${logs.join(" | ")}`);
+    assert.ok(line!.includes(SERVER_URL), `the destination must be named, not implied: ${line}`);
+    assert.ok(
+      !/nowhere else/i.test(line!),
+      `must not claim the conversation stays on this machine -- the daemon uploads it: ${line}`,
+    );
+  });
+});
+
+test("runInit: the capture-off line stays silent about any destination", async () => {
+  const { fetch } = bodyCapturingFetch();
+  const { deps } = fakeDeps();
+  await withHome(async () => {
+    const repo = tmpRepo(SERVER_URL); // no capture block at all -- opt-in, so off
+    const { logs } = await captureConsole(() => withMockFetch(fetch, () => runInit({ cwd: repo, server: SERVER_URL, noAuth: true }, deps)));
+
+    const line = logs.find((l) => l.includes("session capture"));
+    assert.ok(line?.includes("off"), `expected the off line, got: ${logs.join(" | ")}`);
+    assert.ok(!line!.includes(SERVER_URL), "nothing is uploaded when capture is off, so naming a destination would be misleading");
+  });
+});
+
 test("runInit: seeds the repo's settings.designDormantAfter to the coordinator as milliseconds", async () => {
   const { fetch, seedBodies } = bodyCapturingFetch();
   const { deps } = fakeDeps();

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -287,9 +287,20 @@ export async function runInit(options: InitOptions, deps: InitDeps = defaultInit
   // off, so without this a typo'd key (`enable:`, `capture: true`) is
   // indistinguishable from a repo that simply hasn't opted in -- and `init`
   // is where someone who just edited the manifest would look.
+  //
+  // Names the coordinator explicitly (2026-09-11). This line used to end
+  // "on this machine, and nowhere else" -- written for phase 1, when
+  // capture genuinely stopped at the local file, and false from the moment
+  // the daemon's upload shipped. A stale string is bad anywhere; in the one
+  // sentence somebody reads while turning conversation capture *on* it is
+  // the worst kind, because it understates where their words go at exactly
+  // the moment they are deciding whether to let them go there. Consent was
+  // still a deliberate edit to a committed file, so nobody was captured
+  // without opting in -- but they opted in against a description that had
+  // stopped being accurate, which is not the same as having consented.
   console.log(
     captureEnabled(manifest)
-      ? "twing init: session capture ON for this repo -- filtered conversation is written to ~/.twing/sessions/ on this machine, and nowhere else"
+      ? `twing init: session capture ON for this repo -- filtered, redacted conversation is written to ~/.twing/sessions/ on this machine and uploaded to this repo's coordinator (${serverUrl}). Turn it off with \`capture: {enabled: false}\` in .twing/twing.yml.`
       : "twing init: session capture off (set `capture: {enabled: true}` in .twing/twing.yml to turn it on)",
   );
 


### PR DESCRIPTION
`twing init`'s capture-ON line ended **"on this machine, and nowhere else"**. That was written for phase 1, when capture genuinely stopped at `~/.twing/sessions/`. It became false the moment the daemon's coordinator upload shipped — which it did, in 0.2.25, with this line still claiming otherwise.

Found by running `twing init` against the live coordinator right after 0.2.25 deployed, and reading its own output.

A stale string is bad anywhere. In the one sentence somebody reads while deciding whether to let their conversation be recorded, it's the worst kind: it understates where their words go at exactly the moment they're deciding whether to let them go there.

The opt-in itself was never affected — consent is still a deliberate edit to a committed file, and nobody was captured without making that edit. But they made it against a description that had stopped being accurate, and consenting to the wrong description isn't consent to what actually happens.

### Before

```
twing init: session capture ON for this repo -- filtered conversation is
written to ~/.twing/sessions/ on this machine, and nowhere else
```

### After

```
twing init: session capture ON for this repo -- filtered, redacted conversation
is written to ~/.twing/sessions/ on this machine and uploaded to this repo's
coordinator (https://coordination-server.twing.dev). Turn it off with
`capture: {enabled: false}` in .twing/twing.yml.
```

Also says *redacted* as well as filtered, and points at the switch that turns it off.

The capture-off line is unchanged and deliberately stays silent about any destination — nothing is uploaded when it's off, so naming one there would mislead in the other direction. There's a test for that too.

## Tests

Two, pinning both halves. Verified they actually catch the regression by restoring the old string and watching the capture-ON test fail, then restoring the fix. Nothing failed when the string drifted the first time, which is most of why it drifted at all.

Full suite green: 280 / 66 / 454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gFSc5K8tzjjLpRvEXPCJy
